### PR TITLE
feat: add threaded comments system

### DIFF
--- a/README-comments.md
+++ b/README-comments.md
@@ -1,0 +1,36 @@
+# Comments API
+
+This project implements threaded comments with cursor-based pagination using Supabase.
+
+## Endpoints
+
+### `POST /api/comments`
+Create a new comment. Body parameters:
+- `postId`: string
+- `body`: string (<=1000 chars)
+- `parentId` (optional): string – parent comment id for replies.
+
+### `GET /api/comments?postId=...&cursor=...&limit=20`
+Fetch top-level comments for a post. Returns newest comments first and includes up to two preview replies.
+
+### `GET /api/comments/:id/replies?after=...&limit=20`
+Fetch replies for a comment in ascending order starting after the provided cursor.
+
+### `PUT /api/comments/:id`
+Edit a comment. Body: `{ body: string }`.
+
+### `DELETE /api/comments/:id`
+Soft delete a comment – sets `is_deleted=true` and clears body.
+
+### `POST /api/comments/:id/like`
+Toggle like for the current user. Returns `{ like_count, did_like }`.
+
+## Pagination
+- Top-level comments use `created_at` cursor in descending order.
+- Replies use `created_at` cursor in ascending order.
+
+## Safety Filters
+SQL functions exclude comments from users that the viewer has blocked or muted using the `blocks` and `mutes` tables.
+
+## Database
+See `supabase/migrations/20250828090000_comments_system.sql` for full schema, RLS policies and RPC helpers.

--- a/src/app/api/comments/[id]/like/route.ts
+++ b/src/app/api/comments/[id]/like/route.ts
@@ -1,0 +1,22 @@
+/* eslint-env node */
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+)
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const authHeader = req.headers.get('authorization')
+  if (!authHeader) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const token = authHeader.split('Bearer ')[1]
+  const { data: { user }, error } = await supabase.auth.getUser(token)
+  if (error || !user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { data: result, error: toggleError } = await supabase.rpc('toggle_comment_like', {
+    p_comment: params.id
+  })
+  if (toggleError) return NextResponse.json({ error: toggleError.message }, { status: 500 })
+  return NextResponse.json(result ? result[0] : { like_count: 0, did_like: false })
+}

--- a/src/app/api/comments/[id]/replies/route.ts
+++ b/src/app/api/comments/[id]/replies/route.ts
@@ -1,0 +1,33 @@
+/* eslint-env node */
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+)
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const { searchParams } = new URL(req.url)
+  const after = searchParams.get('after') ?? undefined
+  const limit = parseInt(searchParams.get('limit') ?? '20', 10)
+
+  const authHeader = req.headers.get('authorization')
+  const token = authHeader ? authHeader.split('Bearer ')[1] : undefined
+  let viewer: string | undefined
+  if (token) {
+    const { data: { user } } = await supabase.auth.getUser(token)
+    viewer = user?.id
+  }
+
+  const { data, error } = await supabase.rpc('get_comment_replies', {
+    p_viewer: viewer ?? null,
+    p_parent: params.id,
+    p_after: after ?? 'epoch',
+    p_limit: limit
+  })
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  const items = data ?? []
+  const nextAfter = items.length > 0 ? items[items.length - 1].created_at : null
+  return NextResponse.json({ items, nextAfter })
+}

--- a/src/app/api/comments/[id]/route.ts
+++ b/src/app/api/comments/[id]/route.ts
@@ -1,0 +1,49 @@
+/* eslint-env node */
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+)
+
+export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+  const authHeader = req.headers.get('authorization')
+  if (!authHeader) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const token = authHeader.split('Bearer ')[1]
+  const { data: { user }, error } = await supabase.auth.getUser(token)
+  if (error || !user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { body } = await req.json()
+  if (!body || body.length === 0 || body.length > 1000) {
+    return NextResponse.json({ error: 'Invalid body' }, { status: 400 })
+  }
+
+  const { data, error: updateError } = await supabase
+    .from('comments')
+    .update({ body })
+    .eq('id', params.id)
+    .eq('author_id', user.id)
+    .select('*')
+    .single()
+  if (updateError) return NextResponse.json({ error: updateError.message }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+  const authHeader = req.headers.get('authorization')
+  if (!authHeader) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const token = authHeader.split('Bearer ')[1]
+  const { data: { user }, error } = await supabase.auth.getUser(token)
+  if (error || !user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { data, error: delError } = await supabase
+    .from('comments')
+    .update({ is_deleted: true, body: '' })
+    .eq('id', params.id)
+    .eq('author_id', user.id)
+    .select('*')
+    .single()
+  if (delError) return NextResponse.json({ error: delError.message }, { status: 500 })
+  return NextResponse.json(data)
+}

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -1,0 +1,56 @@
+/* eslint-env node */
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+)
+
+export async function POST(req: NextRequest) {
+  const authHeader = req.headers.get('authorization')
+  if (!authHeader) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const token = authHeader.split('Bearer ')[1]
+  const { data: { user }, error: authError } = await supabase.auth.getUser(token)
+  if (authError || !user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { postId, body, parentId } = await req.json()
+  if (!body || body.length === 0 || body.length > 1000) {
+    return NextResponse.json({ error: 'Invalid body' }, { status: 400 })
+  }
+  const { data, error } = await supabase
+    .from('comments')
+    .insert({ post_id: postId, body, parent_id: parentId ?? null, author_id: user.id })
+    .select('*')
+    .single()
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const postId = searchParams.get('postId')
+  if (!postId) return NextResponse.json({ error: 'postId required' }, { status: 400 })
+  const cursor = searchParams.get('cursor') ?? undefined
+  const limit = parseInt(searchParams.get('limit') ?? '20', 10)
+
+  const authHeader = req.headers.get('authorization')
+  const token = authHeader ? authHeader.split('Bearer ')[1] : undefined
+  let viewer: string | undefined
+  if (token) {
+    const { data: { user } } = await supabase.auth.getUser(token)
+    viewer = user?.id
+  }
+
+  const { data, error } = await supabase.rpc('get_post_comments', {
+    p_viewer: viewer ?? null,
+    p_post: postId,
+    p_before: cursor ?? new Date().toISOString(),
+    p_limit: limit,
+    p_preview_replies: 2
+  })
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  const items = data ?? []
+  const nextCursor = items.length > 0 ? items[items.length - 1].created_at : null
+  return NextResponse.json({ items, nextCursor })
+}

--- a/src/components/comments/CommentComposer.tsx
+++ b/src/components/comments/CommentComposer.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+
+interface Props {
+  onSubmit: (body: string) => Promise<void>
+  placeholder?: string
+  autoFocus?: boolean
+}
+
+export function CommentComposer({ onSubmit, placeholder = 'Write a comment...', autoFocus }: Props) {
+  const [body, setBody] = useState('')
+  const [loading, setLoading] = useState(false)
+  const remaining = 1000 - body.length
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!body.trim()) return
+    try {
+      setLoading(true)
+      await onSubmit(body)
+      setBody('')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <Textarea
+        value={body}
+        onChange={e => setBody(e.target.value)}
+        maxLength={1000}
+        placeholder={placeholder}
+        autoFocus={autoFocus}
+        disabled={loading}
+      />
+      <div className="flex justify-between text-sm text-muted-foreground items-center">
+        <span>{remaining}</span>
+        <Button type="submit" disabled={loading || !body.trim()}>Submit</Button>
+      </div>
+    </form>
+  )
+}

--- a/src/components/comments/CommentItem.tsx
+++ b/src/components/comments/CommentItem.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Heart, MessageSquare } from 'lucide-react'
+import { useAuth } from '@/contexts/AuthContext'
+import { Comment, createComment, toggleCommentLike } from '@/lib/comments'
+import { CommentComposer } from './CommentComposer'
+
+interface Props {
+  comment: Comment
+  replies?: Comment[]
+  depth?: number
+  onReplyAdded?: (reply: Comment) => void
+  onLoadMoreReplies?: () => void
+  hasMoreReplies?: boolean
+}
+
+export function CommentItem({
+  comment,
+  replies = [],
+  depth = 0,
+  onReplyAdded,
+  onLoadMoreReplies,
+  hasMoreReplies
+}: Props) {
+  const { user } = useAuth()
+  const [showReply, setShowReply] = useState(false)
+  const [likeData, setLikeData] = useState({ count: comment.like_count, didLike: false })
+
+  const handleLike = async () => {
+    const { like_count, did_like } = await toggleCommentLike(comment.id)
+    setLikeData({ count: like_count, didLike: did_like })
+  }
+
+  const handleReply = async (body: string) => {
+    const reply = await createComment({ postId: comment.post_id, body, parentId: comment.id })
+    onReplyAdded?.(reply)
+    setShowReply(false)
+  }
+
+  return (
+    <div className={`mt-4 ${depth > 0 ? 'ml-4' : ''}`}>
+      <div className="flex items-start gap-2">
+        <div className="flex-1">
+          <div className="text-sm text-muted-foreground">{comment.author_id}</div>
+          <div className="whitespace-pre-line text-sm">{comment.is_deleted ? 'Comment deleted' : comment.body}</div>
+          {!comment.is_deleted && (
+            <div className="flex gap-4 mt-2 text-sm text-muted-foreground">
+              <button onClick={handleLike} className="flex items-center gap-1" aria-label="Like comment">
+                <Heart className="h-4 w-4" fill={likeData.didLike ? 'currentColor' : 'none'} />
+                {likeData.count}
+              </button>
+              {user && (
+                <button onClick={() => setShowReply(!showReply)} className="flex items-center gap-1" aria-label="Reply">
+                  <MessageSquare className="h-4 w-4" /> Reply
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {showReply && user && (
+        <div className="mt-2">
+          <CommentComposer onSubmit={handleReply} placeholder="Write a reply..." autoFocus />
+        </div>
+      )}
+
+      {replies.map(r => (
+        <CommentItem key={r.id} comment={r} depth={depth + 1} />
+      ))}
+
+      {hasMoreReplies && (
+        <Button variant="link" size="sm" onClick={onLoadMoreReplies} className="mt-2">
+          View more replies
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/src/components/comments/CommentThread.tsx
+++ b/src/components/comments/CommentThread.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+import { Comment, CommentWithReplies, createComment, fetchPostComments, fetchCommentReplies } from '@/lib/comments'
+import { CommentComposer } from './CommentComposer'
+import { CommentItem } from './CommentItem'
+import { Button } from '@/components/ui/button'
+
+interface Props {
+  postId: string
+}
+
+interface CommentState extends CommentWithReplies {
+  replies: Comment[]
+  nextAfter: string | null
+}
+
+export function CommentThread({ postId }: Props) {
+  const { user } = useAuth()
+  const [comments, setComments] = useState<CommentState[]>([])
+  const [cursor, setCursor] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
+
+  const loadComments = async (initial = false) => {
+    const { items, nextCursor } = await fetchPostComments(postId, initial ? undefined : cursor ?? undefined, 20, user?.id)
+    const mapped = items.map(c => ({ ...c, replies: c.preview_replies ?? [], nextAfter: null }))
+    setComments(initial ? mapped : [...comments, ...mapped])
+    setCursor(nextCursor)
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    loadComments(true)
+  }, [postId, user?.id])
+
+  const handlePost = async (body: string) => {
+    const newComment = await createComment({ postId, body })
+    setComments([{ ...newComment, replies: [], nextAfter: null }, ...comments])
+  }
+
+  const loadMoreReplies = async (commentId: string) => {
+    const comment = comments.find(c => c.id === commentId)
+    if (!comment) return
+    const { items, nextAfter } = await fetchCommentReplies(commentId, comment.nextAfter ?? undefined, 20, user?.id)
+    comment.replies = [...comment.replies, ...items]
+    comment.nextAfter = nextAfter
+    setComments([...comments])
+  }
+
+  if (loading) {
+    return (
+      <div className="mt-6 space-y-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-20 bg-muted/50 rounded" />
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div className="mt-6">
+      {user && (
+        <div className="mb-4">
+          <CommentComposer onSubmit={handlePost} />
+        </div>
+      )}
+
+      {comments.length === 0 && (
+        <p className="text-center text-sm text-muted-foreground">Be the first to start the conversation.</p>
+      )}
+
+      {comments.map(c => (
+        <CommentItem
+          key={c.id}
+          comment={c}
+          replies={c.replies}
+          hasMoreReplies={c.replies.length >= 2}
+          onLoadMoreReplies={() => loadMoreReplies(c.id)}
+          onReplyAdded={reply => {
+            c.replies = [...c.replies, reply]
+            setComments([...comments])
+          }}
+        />
+      ))}
+
+      {cursor && (
+        <div className="flex justify-center mt-4">
+          <Button variant="outline" onClick={() => { if (!loadingMore) { setLoadingMore(true); loadComments(); setLoadingMore(false); }}}>
+            {loadingMore ? 'Loading...' : 'Load more'}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/comments.ts
+++ b/src/lib/comments.ts
@@ -1,0 +1,121 @@
+import { supabase } from '@/integrations/supabase/client'
+
+export interface Comment {
+  id: string
+  post_id: string
+  author_id: string
+  parent_id: string | null
+  body: string
+  like_count: number
+  is_deleted: boolean
+  created_at: string
+}
+
+export interface CommentWithReplies extends Comment {
+  preview_replies?: Comment[]
+}
+
+// Fetch top level comments for a post
+export async function fetchPostComments(
+  postId: string,
+  cursor?: string,
+  limit = 20,
+  viewer?: string
+) {
+  const { data, error } = await supabase.rpc('get_post_comments', {
+    p_viewer: viewer ?? null,
+    p_post: postId,
+    p_before: cursor ?? new Date().toISOString(),
+    p_limit: limit,
+    p_preview_replies: 2
+  })
+
+  if (error) throw error
+
+  const raw = (data ?? []) as (CommentWithReplies & { preview_replies: Comment[] })[]
+  const items: CommentWithReplies[] = raw.map(row => ({
+    id: row.id,
+    post_id: row.post_id,
+    author_id: row.author_id,
+    parent_id: row.parent_id,
+    body: row.body,
+    like_count: row.like_count,
+    is_deleted: row.is_deleted,
+    created_at: row.created_at,
+    preview_replies: row.preview_replies
+  }))
+
+  const nextCursor = items.length > 0 ? items[items.length - 1].created_at : null
+  return { items, nextCursor }
+}
+
+// Fetch replies for a comment
+export async function fetchCommentReplies(
+  parentId: string,
+  after?: string,
+  limit = 20,
+  viewer?: string
+) {
+  const { data, error } = await supabase.rpc('get_comment_replies', {
+    p_viewer: viewer ?? null,
+    p_parent: parentId,
+    p_after: after ?? 'epoch',
+    p_limit: limit
+  })
+  if (error) throw error
+  const items: Comment[] = data ?? []
+  const nextAfter = items.length > 0 ? items[items.length - 1].created_at : null
+  return { items, nextAfter }
+}
+
+// Create a new comment or reply
+export async function createComment({
+  postId,
+  body,
+  parentId
+}: {
+  postId: string
+  body: string
+  parentId?: string
+}) {
+  const { data, error } = await supabase
+    .from('comments')
+    .insert({ post_id: postId, body, parent_id: parentId ?? null })
+    .select('*')
+    .single()
+  if (error) throw error
+  return data as Comment
+}
+
+// Edit an existing comment
+export async function editComment(id: string, body: string) {
+  const { data, error } = await supabase
+    .from('comments')
+    .update({ body })
+    .eq('id', id)
+    .select('*')
+    .single()
+  if (error) throw error
+  return data as Comment
+}
+
+// Soft delete a comment
+export async function deleteComment(id: string) {
+  const { data, error } = await supabase
+    .from('comments')
+    .update({ is_deleted: true, body: '' })
+    .eq('id', id)
+    .select('*')
+    .single()
+  if (error) throw error
+  return data as Comment
+}
+
+// Toggle like on a comment
+export async function toggleCommentLike(commentId: string) {
+  const { data, error } = await supabase.rpc('toggle_comment_like', {
+    p_comment: commentId
+  })
+  if (error) throw error
+  return data ? data[0] : { like_count: 0, did_like: false }
+}

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import { ArrowLeft, Loader2 } from 'lucide-react'
 import { supabase } from '@/integrations/supabase/client'
 import { type Post } from '@/lib/posts'
+import { CommentThread } from '@/components/comments/CommentThread'
 
 export default function PostDetail() {
   const { id } = useParams<{ id: string }>()
@@ -150,13 +151,8 @@ export default function PostDetail() {
           </div>
           
           <PostCard post={post} onLikeToggle={handleLikeToggle} />
-          
-          {/* Future: Comments section would go here */}
-          <div className="mt-6 p-4 border rounded-lg bg-muted/20">
-            <p className="text-muted-foreground text-center">
-              💬 Comments coming soon in the next release!
-            </p>
-          </div>
+
+          <CommentThread postId={post.id} />
         </div>
       </main>
     </div>

--- a/supabase/migrations/20250828090000_comments_system.sql
+++ b/supabase/migrations/20250828090000_comments_system.sql
@@ -1,0 +1,166 @@
+-- Comments and threaded replies schema
+
+-- comments table
+create table if not exists comments (
+  id uuid primary key default gen_random_uuid(),
+  post_id uuid not null references posts(id) on delete cascade,
+  author_id uuid not null references auth.users(id) on delete cascade,
+  parent_id uuid null references comments(id) on delete cascade,
+  body text not null check (char_length(body) <= 1000),
+  like_count int not null default 0,
+  is_deleted boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
+-- comment likes table
+create table if not exists comment_likes (
+  comment_id uuid not null references comments(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  primary key (comment_id, user_id)
+);
+
+-- add comment counter to posts
+alter table posts add column if not exists comment_count int not null default 0;
+
+-- indexes for efficient pagination
+create index if not exists idx_comments_post_parent_created on comments(post_id, parent_id, created_at desc);
+create index if not exists idx_comments_post_created on comments(post_id, created_at desc);
+create index if not exists idx_comments_parent_created on comments(parent_id, created_at asc);
+
+-- enable RLS
+alter table comments enable row level security;
+alter table comment_likes enable row level security;
+
+-- RLS policies
+create policy if not exists comments_select_all on comments for select using (true);
+create policy if not exists comments_insert_own on comments for insert with check (auth.uid() = author_id);
+create policy if not exists comments_update_own on comments for update using (auth.uid() = author_id) with check (auth.uid() = author_id);
+create policy if not exists comments_delete_own on comments for delete using (auth.uid() = author_id);
+
+create policy if not exists comment_likes_select on comment_likes for select using (true);
+create policy if not exists comment_likes_mutate_own on comment_likes for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+-- triggers to maintain posts.comment_count
+create or replace function trg_comment_insert() returns trigger language plpgsql as $$
+begin
+  update posts set comment_count = comment_count + 1 where id = new.post_id;
+  return new;
+end $$;
+
+create or replace function trg_comment_delete() returns trigger language plpgsql as $$
+begin
+  update posts set comment_count = greatest(comment_count - 1, 0) where id = old.post_id;
+  return old;
+end $$;
+
+drop trigger if exists comments_after_insert on comments;
+create trigger comments_after_insert after insert on comments for each row execute function trg_comment_insert();
+
+drop trigger if exists comments_after_delete on comments;
+create trigger comments_after_delete after delete on comments for each row execute function trg_comment_delete();
+
+-- RPC function to fetch top-level comments with preview replies
+create or replace function get_post_comments(
+  p_viewer uuid,
+  p_post uuid,
+  p_before timestamptz default now(),
+  p_limit int default 20,
+  p_preview_replies int default 2
+) returns table(
+  id uuid, post_id uuid, author_id uuid, parent_id uuid,
+  body text, like_count int, is_deleted boolean, created_at timestamptz,
+  preview_replies jsonb
+) language sql stable as $$
+  with top as (
+    select c.*
+    from comments c
+    where c.post_id = p_post
+      and c.parent_id is null
+      and c.created_at < p_before
+      and not exists (
+        select 1 from blocks b where (b.blocker_id = p_viewer and b.blocked_id = c.author_id)
+                               or (b.blocker_id = c.author_id and b.blocked_id = p_viewer)
+      )
+      and not exists (
+        select 1 from mutes m where m.muter_id = p_viewer and m.muted_id = c.author_id
+      )
+    order by c.created_at desc, c.id desc
+    limit p_limit
+  )
+  select
+    t.id, t.post_id, t.author_id, t.parent_id,
+    t.body, t.like_count, t.is_deleted, t.created_at,
+    (
+      select coalesce(jsonb_agg(jsonb_build_object(
+        'id', r.id,
+        'post_id', r.post_id,
+        'author_id', r.author_id,
+        'parent_id', r.parent_id,
+        'body', r.body,
+        'like_count', r.like_count,
+        'is_deleted', r.is_deleted,
+        'created_at', r.created_at
+      ) order by r.created_at asc), '[]'::jsonb)
+      from (
+        select r.*
+        from comments r
+        where r.parent_id = t.id
+          and not exists (
+            select 1 from blocks b where (b.blocker_id = p_viewer and b.blocked_id = r.author_id)
+                                   or (b.blocker_id = r.author_id and b.blocked_id = p_viewer)
+          )
+          and not exists (
+            select 1 from mutes m where m.muter_id = p_viewer and m.muted_id = r.author_id
+          )
+        order by r.created_at asc
+        limit p_preview_replies
+      ) r
+    ) as preview_replies
+  from top t;
+$$;
+
+-- RPC function to fetch replies for a comment
+create or replace function get_comment_replies(
+  p_viewer uuid,
+  p_parent uuid,
+  p_after timestamptz default 'epoch'::timestamptz,
+  p_limit int default 20
+) returns table(
+  id uuid, post_id uuid, author_id uuid, parent_id uuid,
+  body text, like_count int, is_deleted boolean, created_at timestamptz
+) language sql stable as $$
+  select c.*
+  from comments c
+  where c.parent_id = p_parent
+    and c.created_at > p_after
+    and not exists (
+      select 1 from blocks b where (b.blocker_id = p_viewer and b.blocked_id = c.author_id)
+                             or (b.blocker_id = c.author_id and b.blocked_id = p_viewer)
+    )
+    and not exists (
+      select 1 from mutes m where m.muter_id = p_viewer and m.muted_id = c.author_id
+    )
+  order by c.created_at asc, c.id asc
+  limit p_limit;
+$$;
+
+-- RPC to toggle like on a comment and return new like count and like status
+create or replace function toggle_comment_like(p_comment uuid)
+returns table(like_count int, did_like boolean)
+language plpgsql as $$
+declare
+  v_user uuid := auth.uid();
+begin
+  if exists(select 1 from comment_likes where comment_id = p_comment and user_id = v_user) then
+    delete from comment_likes where comment_id = p_comment and user_id = v_user;
+    update comments set like_count = greatest(like_count - 1, 0) where id = p_comment returning like_count into like_count;
+    did_like := false;
+  else
+    insert into comment_likes(comment_id, user_id) values (p_comment, v_user);
+    update comments set like_count = like_count + 1 where id = p_comment returning like_count into like_count;
+    did_like := true;
+  end if;
+  return next;
+end;
+$$;


### PR DESCRIPTION
## Summary
- add Supabase schema and RPC helpers for threaded comments
- expose API routes and client utilities for comments, replies and likes
- build React components for comment composer, items and thread
- integrate comment thread on post detail page and document API usage

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any / no-case-declarations / etc.)

------
https://chatgpt.com/codex/tasks/task_e_68b0a319fa58832790760076c069cdfe