### PR TITLE
feat: add in-app notifications system

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import Logout from '@/pages/Logout'
 import AuthUpgrade from '@/pages/AuthUpgrade'
 import FollowRequests from '@/pages/FollowRequests'
 import Search from '@/pages/Search'
+import NotificationsPage from '@/pages/Notifications'
 
 function App() {
   return (
@@ -72,16 +73,24 @@ function App() {
                 </RouteGuard>
               } 
             />
-            <Route 
-              path="/search" 
+            <Route
+              path="/search"
               element={
                 <RouteGuard>
                   <Search />
                 </RouteGuard>
-              } 
+              }
             />
-            <Route 
-              path="/requests" 
+            <Route
+              path="/notifications"
+              element={
+                <RouteGuard>
+                  <NotificationsPage />
+                </RouteGuard>
+              }
+            />
+            <Route
+              path="/requests"
               element={
                 <RouteGuard>
                   <FollowRequests />

--- a/src/app/api/notifications/read/route.ts
+++ b/src/app/api/notifications/read/route.ts
@@ -1,0 +1,29 @@
+/* eslint-env node */
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+)
+
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => ({}))
+  const ids: string[] | undefined = body.ids
+  const allUpTo: string | undefined = body.allUpTo
+
+  const authHeader = req.headers.get('authorization')
+  if (!authHeader) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  const token = authHeader.split('Bearer ')[1]
+  const { data: { user } } = await supabase.auth.getUser(token)
+  if (!user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  let q = supabase.from('notifications').update({ read_at: new Date().toISOString() }).eq('user_id', user.id)
+  if (ids?.length) q = q.in('id', ids)
+  else if (allUpTo) q = q.lte('created_at', allUpTo)
+  else return NextResponse.json({ error: 'bad_request' }, { status: 400 })
+
+  const { error } = await q
+  if (error) return NextResponse.json({ error: 'update_failed' }, { status: 500 })
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,0 +1,60 @@
+/* eslint-env node */
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+)
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const limit = Math.min(parseInt(searchParams.get('limit') || '30', 10), 50)
+  const cursor = searchParams.get('cursor')
+
+  const authHeader = req.headers.get('authorization')
+  if (!authHeader) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  const token = authHeader.split('Bearer ')[1]
+
+  const { data: { user }, error: uErr } = await supabase.auth.getUser(token)
+  if (uErr || !user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const before = cursor ?? new Date().toISOString()
+
+  const { data: rows, error } = await supabase
+    .from('notifications')
+    .select('id, type, post_id, comment_id, actor_id, created_at, read_at, meta')
+    .eq('user_id', user.id)
+    .lt('created_at', before)
+    .order('created_at', { ascending: false })
+    .limit(limit)
+
+  if (error) {
+    console.error('[notifications:list]', error)
+    return NextResponse.json({ error: 'list_failed' }, { status: 500 })
+  }
+
+  const actorIds = Array.from(new Set(rows?.map(r => r.actor_id) ?? []))
+  let actors: Record<string, any> = {}
+  if (actorIds.length) {
+    const { data: profiles } = await supabase
+      .from('profiles')
+      .select('id, username, display_name, avatar_url')
+      .in('id', actorIds)
+    actors = Object.fromEntries((profiles ?? []).map(p => [p.id, p]))
+  }
+
+  const items = (rows ?? []).map(r => ({
+    id: r.id,
+    type: r.type,
+    postId: r.post_id,
+    commentId: r.comment_id,
+    createdAt: r.created_at,
+    readAt: r.read_at,
+    meta: r.meta ?? {},
+    actor: actors[r.actor_id] ?? { id: r.actor_id, username: 'unknown' },
+  }))
+
+  const nextCursor = items.length ? items[items.length - 1].createdAt : null
+  return NextResponse.json({ items, nextCursor })
+}

--- a/src/app/api/notifications/unread-count/route.ts
+++ b/src/app/api/notifications/unread-count/route.ts
@@ -1,0 +1,24 @@
+/* eslint-env node */
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+)
+
+export async function GET(req: NextRequest) {
+  const authHeader = req.headers.get('authorization')
+  if (!authHeader) return NextResponse.json({ count: 0 })
+  const token = authHeader.split('Bearer ')[1]
+  const { data: { user } } = await supabase.auth.getUser(token)
+  if (!user) return NextResponse.json({ count: 0 })
+
+  const { count } = await supabase
+    .from('notifications')
+    .select('id', { count: 'exact', head: true })
+    .eq('user_id', user.id)
+    .is('read_at', null)
+
+  return NextResponse.json({ count: count ?? 0 })
+}

--- a/src/app/api/posts/[id]/like/route.ts
+++ b/src/app/api/posts/[id]/like/route.ts
@@ -1,0 +1,68 @@
+/* eslint-env node */
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+)
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const authHeader = req.headers.get('authorization')
+  if (!authHeader) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const token = authHeader.split('Bearer ')[1]
+  const { data: { user }, error } = await supabase.auth.getUser(token)
+  if (error || !user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { data: existing } = await supabase
+    .from('post_likes')
+    .select('post_id')
+    .eq('post_id', params.id)
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (existing) {
+    await supabase
+      .from('post_likes')
+      .delete()
+      .eq('post_id', params.id)
+      .eq('user_id', user.id)
+    const { count } = await supabase
+      .from('post_likes')
+      .select('post_id', { count: 'exact', head: true })
+      .eq('post_id', params.id)
+    return NextResponse.json({ like_count: count ?? 0, did_like: false })
+  }
+
+  const { error: insertError } = await supabase
+    .from('post_likes')
+    .insert({ post_id: params.id, user_id: user.id })
+  if (insertError) return NextResponse.json({ error: insertError.message }, { status: 500 })
+
+  // notify post author
+  try {
+    const { data: post } = await supabase
+      .from('posts')
+      .select('author_id')
+      .eq('id', params.id)
+      .single()
+    if (post?.author_id) {
+      await supabase.rpc('create_notification', {
+        p_user: post.author_id,
+        p_actor: user.id,
+        p_type: 'post_like',
+        p_post: params.id,
+        p_comment: null,
+        p_meta: {}
+      })
+    }
+  } catch (e) {
+    console.error('[post_like:notify]', e)
+  }
+
+  const { count } = await supabase
+    .from('post_likes')
+    .select('post_id', { count: 'exact', head: true })
+    .eq('post_id', params.id)
+  return NextResponse.json({ like_count: count ?? 0, did_like: true })
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -3,24 +3,22 @@ import { useAuth } from '@/contexts/AuthContext'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
-import { 
-  Home, 
-  Search, 
-  Users, 
-  Bell, 
-  MessageCircle, 
-  Bookmark, 
-  User,
+import {
+  Home,
+  Search,
+  Users,
+  MessageCircle,
+  Bookmark,
   Settings,
   LogOut
 } from 'lucide-react'
+import NotificationsBell from '@/components/notifications/NotificationsBell'
 
 const navigation = [
   { name: 'Home', href: '/', icon: Home },
   { name: 'Search', href: '/search', icon: Search },
   { name: 'Requests', href: '/requests', icon: Users },
   { name: 'Discovery', href: '/discovery', icon: Search },
-  { name: 'Notifications', href: '/notifications', icon: Bell },
   { name: 'Messages', href: '/messages', icon: MessageCircle },
   { name: 'Saved', href: '/saved', icon: Bookmark },
 ]
@@ -37,9 +35,9 @@ export function Sidebar() {
         {/* Logo */}
         <div className="p-4 border-b border-border">
           <Link to="/" className="flex items-center gap-3 group">
-            <img 
-              src="/lovable-uploads/d686f771-cade-4bce-8c91-d54aa84ae0f5.png" 
-              alt="Under Pines" 
+            <img
+              src="/lovable-uploads/d686f771-cade-4bce-8c91-d54aa84ae0f5.png"
+              alt="Under Pines"
               className="w-10 h-10 rounded-full transition-transform group-hover:scale-105"
             />
             <div className="flex items-center gap-2">
@@ -61,11 +59,11 @@ export function Sidebar() {
                   <Link
                     to={item.href}
                     className={cn(
-                      "flex items-center gap-3 px-3 py-2.5 rounded-md text-sm font-medium transition-all",
-                      "hover:bg-muted/20 hover:text-accent interactive-glow",
+                      'flex items-center gap-3 px-3 py-2.5 rounded-md text-sm font-medium transition-all',
+                      'hover:bg-muted/20 hover:text-accent interactive-glow',
                       isActive
-                        ? "bg-primary/20 text-accent border-l-2 border-primary"
-                        : "text-secondary-foreground/80"
+                        ? 'bg-primary/20 text-accent border-l-2 border-primary'
+                        : 'text-secondary-foreground/80',
                     )}
                   >
                     <item.icon className="h-5 w-5 flex-shrink-0" />
@@ -74,6 +72,9 @@ export function Sidebar() {
                 </li>
               )
             })}
+            <li>
+              <NotificationsBell isActive={location.pathname === '/notifications'} />
+            </li>
           </ul>
         </nav>
 
@@ -96,7 +97,7 @@ export function Sidebar() {
               <p className="text-xs text-muted-foreground truncate">@{user.username}</p>
             </div>
           </Link>
-          
+
           <Link
             to="/settings/profile"
             className="flex items-center gap-3 p-3 mt-2 rounded-md hover:bg-muted/20 transition-all interactive-glow text-secondary-foreground/80"
@@ -104,7 +105,7 @@ export function Sidebar() {
             <Settings className="h-4 w-4" />
             <span className="text-sm">Settings</span>
           </Link>
-          
+
           <Link
             to="/logout"
             className="flex items-center gap-3 p-3 mt-1 rounded-md hover:bg-destructive/20 hover:text-destructive transition-all interactive-glow text-secondary-foreground/80"

--- a/src/components/notifications/NotificationsBell.tsx
+++ b/src/components/notifications/NotificationsBell.tsx
@@ -1,0 +1,56 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { supabase } from '@/integrations/supabase/client'
+import { Bell } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface Props { isActive?: boolean }
+
+export default function NotificationsBell({ isActive }: Props) {
+  const [count, setCount] = useState<number>(0)
+
+  useEffect(() => {
+    let sub: ReturnType<typeof supabase.channel> | undefined
+    async function init() {
+      const { data: { session } } = await supabase.auth.getSession()
+      const token = session?.access_token
+      const res = await fetch('/api/notifications/unread-count', {
+        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+        cache: 'no-store'
+      })
+      const json = await res.json().catch(() => ({ count: 0 }))
+      setCount(json.count || 0)
+
+      const uid = session?.user?.id
+      if (!uid) return
+      sub = supabase
+        .channel(`notifs:${uid}`)
+        .on('postgres_changes',
+          { event: 'INSERT', schema: 'public', table: 'notifications', filter: `user_id=eq.${uid}` },
+          () => setCount(c => c + 1)
+        )
+        .subscribe()
+    }
+    init()
+    return () => { if (sub) supabase.removeChannel(sub) }
+  }, [])
+
+  return (
+    <Link
+      to="/notifications"
+      className={cn(
+        'relative flex items-center gap-3 px-3 py-2.5 rounded-md text-sm font-medium transition-all hover:bg-muted/20 hover:text-accent interactive-glow',
+        isActive ? 'bg-primary/20 text-accent border-l-2 border-primary' : 'text-secondary-foreground/80'
+      )}
+    >
+      <Bell className="h-5 w-5 flex-shrink-0" />
+      <span>Notifications</span>
+      {count > 0 && (
+        <span className="absolute right-3 top-2 min-w-[18px] h-[18px] px-1 rounded-full bg-accent-warm text-black text-[11px] leading-[18px] text-center">
+          {count > 99 ? '99+' : count}
+        </span>
+      )}
+    </Link>
+  )
+}

--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+// Using regular img since app is Vite-based
+import { supabase } from '@/integrations/supabase/client'
+import { Sidebar } from '@/components/layout/Sidebar'
+import { MobileNav } from '@/components/layout/MobileNav'
+
+export type Notif = {
+  id: string
+  type: 'follow'|'follow_request'|'follow_accept'|'post_like'|'post_comment'|'comment_reply'
+  postId?: string | null
+  commentId?: string | null
+  createdAt: string
+  readAt?: string | null
+  meta?: Record<string, unknown>
+  actor: { id: string; username: string; display_name?: string | null; avatar_url?: string | null }
+}
+
+export default function NotificationsPage() {
+  const [items, setItems] = useState<Notif[]>([])
+  const [cursor, setCursor] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [done, setDone] = useState(false)
+
+  async function loadMore() {
+    if (loading || done) return
+    setLoading(true)
+    const qs = new URLSearchParams()
+    if (cursor) qs.set('cursor', cursor)
+    const { data: { session } } = await supabase.auth.getSession()
+    const token = session?.access_token
+    const res = await fetch(`/api/notifications?${qs.toString()}`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+      cache: 'no-store'
+    })
+    const json = await res.json()
+    setItems(prev => [...prev, ...json.items])
+    setCursor(json.nextCursor)
+    setDone(!json.nextCursor)
+    setLoading(false)
+  }
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { loadMore() }, [])
+
+  async function markAllRead() {
+    const last = items[items.length - 1]?.createdAt || new Date().toISOString()
+    const { data: { session } } = await supabase.auth.getSession()
+    const token = session?.access_token
+    await fetch('/api/notifications/read', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {})
+      },
+      body: JSON.stringify({ allUpTo: last })
+    })
+    setItems(prev => prev.map(n => ({ ...n, readAt: n.readAt ?? new Date().toISOString() })))
+  }
+
+  function textFor(n: Notif) {
+    const name = n.actor.display_name || n.actor.username
+    switch (n.type) {
+      case 'follow':         return `${name} started following you`
+      case 'follow_request': return `${name} requested to follow you`
+      case 'follow_accept':  return `${name} accepted your follow request`
+      case 'post_like':      return `${name} liked your post`
+      case 'post_comment':   return `${name} commented on your post`
+      case 'comment_reply':  return `${name} replied to your comment`
+    }
+  }
+
+  function linkFor(n: Notif) {
+    if (n.postId) return `/post/${n.postId}${n.commentId ? `#c-${n.commentId}` : ''}`
+    return `/${n.actor.username}`
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Sidebar />
+      <main className="ml-0 md:ml-60 pb-20 md:pb-0">
+        <div className="max-w-2xl mx-auto p-4">
+          <div className="flex items-center justify-between mb-4">
+            <h1 className="text-xl font-semibold">Notifications</h1>
+            <button onClick={markAllRead} className="text-sm text-accent-warm hover:opacity-90">Mark all as read</button>
+          </div>
+
+          <ul className="space-y-2">
+            {items.map(n => (
+              <li key={n.id} className={`p-3 rounded-md bg-background-panel ${!n.readAt ? 'outline outline-1 outline-accent-warm/40' : ''}`}>
+                <Link to={linkFor(n)} className="flex items-center gap-3">
+                  <div className="relative h-10 w-10 rounded-full overflow-hidden bg-black/20">
+                    {n.actor.avatar_url && (
+                      <img src={n.actor.avatar_url} alt="" className="h-full w-full object-cover" />
+                    )}
+                  </div>
+                  <div className="min-w-0">
+                    <div className="text-sm">{textFor(n)}</div>
+                    {n.meta?.excerpt && <div className="text-xs text-text-light/70 truncate">“{n.meta.excerpt}”</div>}
+                    <div className="text-xs text-text-light/50">{new Date(n.createdAt).toLocaleString()}</div>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+
+          {!done && (
+            <div className="flex justify-center py-6">
+              <button onClick={loadMore} disabled={loading} className="px-4 h-9 rounded-md bg-background-sand text-black">
+                {loading ? 'Loading…' : 'Load more'}
+              </button>
+            </div>
+          )}
+        </div>
+      </main>
+      <MobileNav />
+    </div>
+  )
+}

--- a/supabase/functions/follow-requests/index.ts
+++ b/supabase/functions/follow-requests/index.ts
@@ -115,9 +115,9 @@ Deno.serve(async (req) => {
         // Create follow relationship
         const { error: followError } = await supabase
           .from('follows')
-          .insert({ 
-            follower_id: request.requester_id, 
-            followee_id: request.target_id 
+          .insert({
+            follower_id: request.requester_id,
+            followee_id: request.target_id
           })
 
         if (followError && !followError.message.includes('duplicate key value')) {
@@ -127,6 +127,17 @@ Deno.serve(async (req) => {
             { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
           )
         }
+
+        // notify requester of acceptance
+        const { error: notifError } = await supabase.rpc('create_notification', {
+          p_user: request.requester_id,
+          p_actor: user.id,
+          p_type: 'follow_accept',
+          p_post: null,
+          p_comment: null,
+          p_meta: {}
+        })
+        if (notifError) console.error('Notify error:', notifError)
 
         // Delete the request
         const { error: deleteError } = await supabase

--- a/supabase/migrations/20250901000000_notifications.sql
+++ b/supabase/migrations/20250901000000_notifications.sql
@@ -1,0 +1,106 @@
+-- Notifications system
+
+-- enum for types
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'notif_type') THEN
+    CREATE TYPE notif_type AS ENUM (
+      'follow','follow_request','follow_accept','post_like','post_comment','comment_reply'
+    );
+  END IF;
+END $$;
+
+-- notifications table
+CREATE TABLE IF NOT EXISTS notifications (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  actor_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  type notif_type NOT NULL,
+  post_id uuid NULL REFERENCES posts(id) ON DELETE SET NULL,
+  comment_id uuid NULL REFERENCES comments(id) ON DELETE SET NULL,
+  meta jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  read_at timestamptz NULL
+);
+
+-- indexes
+CREATE INDEX IF NOT EXISTS idx_notifications_user_created ON notifications(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_notifications_unread ON notifications(user_id) WHERE read_at IS NULL;
+
+-- RLS
+ALTER TABLE notifications ENABLE ROW LEVEL SECURITY;
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename='notifications' AND policyname='notifs_select_own'
+  ) THEN
+    CREATE POLICY notifs_select_own ON notifications
+      FOR SELECT USING (auth.uid() = user_id);
+  END IF;
+END $$;
+-- inserts occur via SECURITY DEFINER function
+
+-- helper function with safety checks
+CREATE OR REPLACE FUNCTION create_notification(
+  p_user uuid,
+  p_actor uuid,
+  p_type notif_type,
+  p_post uuid DEFAULT NULL,
+  p_comment uuid DEFAULT NULL,
+  p_meta jsonb DEFAULT '{}'::jsonb
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  -- do not notify self
+  IF p_user = p_actor THEN
+    RETURN;
+  END IF;
+
+  -- blocks either direction
+  IF EXISTS (
+    SELECT 1 FROM blocks b
+    WHERE (b.blocker_id = p_user AND b.blocked_id = p_actor)
+       OR (b.blocker_id = p_actor AND b.blocked_id = p_user)
+  ) THEN
+    RETURN;
+  END IF;
+
+  -- recipient muted actor
+  IF EXISTS (
+    SELECT 1 FROM mutes m
+    WHERE m.muter_id = p_user AND m.muted_id = p_actor
+  ) THEN
+    RETURN;
+  END IF;
+
+  INSERT INTO notifications(user_id, actor_id, type, post_id, comment_id, meta)
+  VALUES (p_user, p_actor, p_type, p_post, p_comment, p_meta);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION create_notification(uuid,uuid,notif_type,uuid,uuid,jsonb) TO anon, authenticated;
+
+-- follow trigger
+CREATE OR REPLACE FUNCTION trig_follow_notif() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  PERFORM create_notification(NEW.followee_id, NEW.follower_id, 'follow', NULL, NULL, '{}'::jsonb);
+  RETURN NEW;
+END;$$;
+DROP TRIGGER IF EXISTS trg_follow_notif ON follows;
+CREATE TRIGGER trg_follow_notif
+AFTER INSERT ON follows
+FOR EACH ROW EXECUTE FUNCTION trig_follow_notif();
+
+-- follow request trigger
+CREATE OR REPLACE FUNCTION trig_follow_request_notif() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  PERFORM create_notification(NEW.target_id, NEW.requester_id, 'follow_request', NULL, NULL, '{}'::jsonb);
+  RETURN NEW;
+END;$$;
+DROP TRIGGER IF EXISTS trg_follow_request_notif ON follow_requests;
+CREATE TRIGGER trg_follow_request_notif
+AFTER INSERT ON follow_requests
+FOR EACH ROW EXECUTE FUNCTION trig_follow_request_notif();


### PR DESCRIPTION
## Summary
- add notifications DB schema and safety-aware insertion helper
- expose API routes for listing, marking read, unread count, and post like toggle
- implement notifications bell, sidebar integration, and notifications page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, unexpected lexical declaration, require import)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b0c2b0d08327a44a7e883010b010