### PR TITLE
feat: scaffold direct messaging

### DIFF
--- a/README-dm.md
+++ b/README-dm.md
@@ -1,0 +1,38 @@
+# Direct Messaging (DM) Overview
+
+This document describes the data model and API flows for the direct messaging
+feature. The implementation uses Supabase Postgres with row level security and
+realtime channels.
+
+## Schema
+- **dm_conversations** – container for a 1:1 conversation.
+- **dm_members** – membership rows with `state` (`active` or `pending`) and
+  `last_read_at` for read receipts.
+- **dm_messages** – individual messages with optional `attachments` metadata.
+
+See `supabase/migrations/20250902000001_dm_messaging.sql` for full SQL including
+indexes, RLS policies and RPC helpers (`dm_start`, `dm_set_request`,
+`dm_mark_read`).
+
+## Requests flow
+Starting a conversation with a private account creates the conversation with the
+target user in `pending` state. The target may accept or decline the request via
+`dm_set_request`. Declining removes their membership and deletes the
+conversation if no members remain.
+
+## API helpers
+Client-side helpers are provided in `src/lib/dm.ts`:
+- `startConversation` – invoke `dm_start` RPC.
+- `fetchThreads` – list conversations for inbox or requests.
+- `fetchMessages` – load messages for a conversation.
+- `sendMessage` – insert a new message.
+- `markThreadRead` – update `last_read_at`.
+
+## UI components
+Placeholder UI components live under `src/components/dm/` including:
+`ThreadsList`, `ConversationView`, `DMComposer`, `RequestBanner` and
+`TypingIndicator`. Pages `/messages` and `/messages/requests` wire these together
+using React Router.
+
+Further work is needed to support attachments, realtime updates, typing
+indicators and full request workflows.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,8 @@ import AuthUpgrade from '@/pages/AuthUpgrade'
 import FollowRequests from '@/pages/FollowRequests'
 import Search from '@/pages/Search'
 import NotificationsPage from '@/pages/Notifications'
+import Messages from '@/pages/Messages'
+import MessageRequests from '@/pages/MessageRequests'
 
 function App() {
   return (
@@ -86,6 +88,22 @@ function App() {
               element={
                 <RouteGuard>
                   <NotificationsPage />
+                </RouteGuard>
+              }
+            />
+            <Route
+              path="/messages"
+              element={
+                <RouteGuard>
+                  <Messages />
+                </RouteGuard>
+              }
+            />
+            <Route
+              path="/messages/requests"
+              element={
+                <RouteGuard>
+                  <MessageRequests />
                 </RouteGuard>
               }
             />

--- a/src/components/dm/ConversationView.tsx
+++ b/src/components/dm/ConversationView.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useRef, useState } from 'react'
+import { DMMessage, fetchMessages } from '@/lib/dm'
+import { Loader2 } from 'lucide-react'
+
+interface ConversationViewProps {
+  conversationId: string
+}
+
+export function ConversationView({ conversationId }: ConversationViewProps) {
+  const [messages, setMessages] = useState<DMMessage[]>([])
+  const [loading, setLoading] = useState(true)
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await fetchMessages(conversationId)
+        setMessages(data)
+        setTimeout(() => bottomRef.current?.scrollIntoView({ behavior: 'smooth' }), 0)
+      } catch (e) {
+        console.error('Failed to load messages', e)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [conversationId])
+
+  if (loading) {
+    return (
+      <div className="flex justify-center p-4">
+        <Loader2 className="h-6 w-6 animate-spin" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col h-full overflow-y-auto p-4 space-y-2">
+      {messages.map(m => (
+        <div key={m.id} className="max-w-[80%] rounded-lg bg-muted p-2">
+          {m.body}
+        </div>
+      ))}
+      <div ref={bottomRef} />
+    </div>
+  )
+}

--- a/src/components/dm/DMComposer.tsx
+++ b/src/components/dm/DMComposer.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react'
+import { sendMessage } from '@/lib/dm'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+
+interface DMComposerProps {
+  conversationId: string
+  onSend?: () => void
+}
+
+export function DMComposer({ conversationId, onSend }: DMComposerProps) {
+  const [text, setText] = useState('')
+  const [sending, setSending] = useState(false)
+
+  async function handleSend() {
+    if (!text.trim()) return
+    try {
+      setSending(true)
+      await sendMessage(conversationId, text)
+      setText('')
+      onSend?.()
+    } catch (e) {
+      console.error('Failed to send message', e)
+    } finally {
+      setSending(false)
+    }
+  }
+
+  return (
+    <div className="border-t p-4 space-y-2">
+      <Textarea
+        value={text}
+        onChange={e => setText(e.target.value)}
+        placeholder="Write a message"
+        rows={2}
+      />
+      <div className="flex justify-end">
+        <Button onClick={handleSend} disabled={sending || !text.trim()}>
+          Send
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/dm/RequestBanner.tsx
+++ b/src/components/dm/RequestBanner.tsx
@@ -1,0 +1,34 @@
+import { Button } from '@/components/ui/button'
+import { supabase } from '@/integrations/supabase/client'
+
+interface RequestBannerProps {
+  conversationId: string
+  onAction?: (action: 'accept' | 'decline') => void
+}
+
+export function RequestBanner({ conversationId, onAction }: RequestBannerProps) {
+  async function handle(action: 'accept' | 'decline') {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) return
+    try {
+      await supabase.rpc('dm_set_request', {
+        p_me: user.id,
+        p_conversation: conversationId,
+        p_action: action
+      })
+      onAction?.(action)
+    } catch (e) {
+      console.error('Failed to update request', e)
+    }
+  }
+
+  return (
+    <div className="bg-muted p-3 flex items-center justify-between">
+      <span className="text-sm">This conversation is pending</span>
+      <div className="space-x-2">
+        <Button size="sm" onClick={() => handle('accept')}>Accept</Button>
+        <Button size="sm" variant="outline" onClick={() => handle('decline')}>Decline</Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/dm/ThreadsList.tsx
+++ b/src/components/dm/ThreadsList.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react'
+import { fetchThreads, DMThread } from '@/lib/dm'
+import { Loader2 } from 'lucide-react'
+
+interface ThreadsListProps {
+  box?: 'inbox' | 'requests'
+  onSelect?: (thread: DMThread) => void
+}
+
+export function ThreadsList({ box = 'inbox', onSelect }: ThreadsListProps) {
+  const [threads, setThreads] = useState<DMThread[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await fetchThreads(box)
+        setThreads(data as DMThread[])
+      } catch (e) {
+        console.error('Failed to load threads', e)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [box])
+
+  if (loading) {
+    return (
+      <div className="flex justify-center p-4">
+        <Loader2 className="h-6 w-6 animate-spin" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="divide-y">
+      {threads.map(t => (
+        <button
+          key={t.id}
+          onClick={() => onSelect?.(t)}
+          className="w-full text-left p-4 hover:bg-accent"
+        >
+          <div className="font-medium">{t.other_user.display_name || t.other_user.username}</div>
+          {t.last_message && (
+            <div className="text-sm text-muted-foreground truncate">
+              {t.last_message.body}
+            </div>
+          )}
+        </button>
+      ))}
+      {threads.length === 0 && (
+        <div className="p-4 text-muted-foreground text-sm">No messages</div>
+      )}
+    </div>
+  )
+}

--- a/src/components/dm/TypingIndicator.tsx
+++ b/src/components/dm/TypingIndicator.tsx
@@ -1,0 +1,13 @@
+interface TypingIndicatorProps {
+  isTyping: boolean
+  username?: string
+}
+
+export function TypingIndicator({ isTyping, username }: TypingIndicatorProps) {
+  if (!isTyping) return null
+  return (
+    <div className="px-4 py-2 text-sm text-muted-foreground">
+      {username ? `${username} is typing...` : 'Typing...'}
+    </div>
+  )
+}

--- a/src/lib/dm.ts
+++ b/src/lib/dm.ts
@@ -1,0 +1,102 @@
+import { supabase } from '@/integrations/supabase/client'
+
+export interface DMThread {
+  id: string
+  other_user: {
+    id: string
+    username: string
+    display_name?: string
+    avatar_url?: string
+  }
+  last_message?: DMMessage
+  unread_count: number
+  state: 'active' | 'pending'
+  last_read_at: string
+}
+
+export interface DMMessage {
+  id: string
+  conversation_id: string
+  author_id: string
+  body: string
+  attachments: Attachment[]
+  created_at: string
+  is_deleted: boolean
+}
+
+export interface Attachment {
+  type: 'image' | 'video'
+  [key: string]: unknown
+}
+
+// Start a conversation or fetch existing conversation id
+export async function startConversation(otherUserId: string) {
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+
+  const { data, error } = await supabase.rpc('dm_start', {
+    p_me: user.id,
+    p_other: otherUserId
+  })
+
+  if (error) throw error
+  return data as string
+}
+
+// Fetch threads for inbox or requests
+export async function fetchThreads(box: 'inbox' | 'requests', limit = 20) {
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+
+  const state = box === 'inbox' ? 'active' : 'pending'
+  const { data, error } = await supabase
+    .from('dm_members')
+    .select('conversation_id, state, last_read_at, dm_conversations (*), profiles!dm_members_user_id_fkey (*)')
+    .eq('user_id', user.id)
+    .eq('state', state)
+    .order('created_at', { ascending: false })
+    .limit(limit)
+
+  if (error) throw error
+  return data
+}
+
+export async function fetchMessages(conversationId: string, after?: string, limit = 50) {
+  const query = supabase
+    .from('dm_messages')
+    .select('*')
+    .eq('conversation_id', conversationId)
+    .order('created_at', { ascending: true })
+    .limit(limit)
+  if (after) query.gt('created_at', after)
+  const { data, error } = await query
+  if (error) throw error
+  return data as DMMessage[]
+}
+
+export async function sendMessage(conversationId: string, text: string, attachments: Attachment[] = []) {
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+  const { data, error } = await supabase
+    .from('dm_messages')
+    .insert({
+      conversation_id: conversationId,
+      author_id: user.id,
+      body: text,
+      attachments
+    })
+    .select()
+    .single()
+  if (error) throw error
+  return data as DMMessage
+}
+
+export async function markThreadRead(conversationId: string) {
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+  const { error } = await supabase.rpc('dm_mark_read', {
+    p_me: user.id,
+    p_conversation: conversationId
+  })
+  if (error) throw error
+}

--- a/src/pages/MessageRequests.tsx
+++ b/src/pages/MessageRequests.tsx
@@ -1,0 +1,9 @@
+import { ThreadsList } from '@/components/dm/ThreadsList'
+
+export default function MessageRequests() {
+  return (
+    <div className="min-h-screen">
+      <ThreadsList box="requests" />
+    </div>
+  )
+}

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react'
+import { ThreadsList } from '@/components/dm/ThreadsList'
+import { ConversationView } from '@/components/dm/ConversationView'
+import { DMComposer } from '@/components/dm/DMComposer'
+import { DMThread } from '@/lib/dm'
+import { RequestBanner } from '@/components/dm/RequestBanner'
+
+export default function Messages() {
+  const [selected, setSelected] = useState<DMThread | null>(null)
+
+  return (
+    <div className="min-h-screen grid md:grid-cols-[320px_1fr]">
+      <div className="border-r">
+        <ThreadsList onSelect={setSelected} />
+      </div>
+      <div className="flex flex-col h-full">
+        {!selected && (
+          <div className="flex-1 flex items-center justify-center text-muted-foreground">
+            Select a conversation
+          </div>
+        )}
+        {selected && (
+          <div className="flex flex-col h-full">
+            {selected.state === 'pending' && (
+              <RequestBanner conversationId={selected.id} onAction={() => setSelected(null)} />
+            )}
+            <div className="flex-1">
+              <ConversationView conversationId={selected.id} />
+            </div>
+            {selected.state === 'active' && (
+              <DMComposer conversationId={selected.id} />
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/supabase/migrations/20250902000001_dm_messaging.sql
+++ b/supabase/migrations/20250902000001_dm_messaging.sql
@@ -1,0 +1,170 @@
+-- Direct Messages schema and RPC functions
+
+-- conversations (1:1 for MVP; future: is_group)
+create table if not exists dm_conversations (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz default now()
+);
+
+-- members with per-user state
+create type dm_member_state as enum ('active','pending'); -- pending = request awaiting acceptance
+create table if not exists dm_members (
+  conversation_id uuid references dm_conversations(id) on delete cascade,
+  user_id uuid references auth.users(id) on delete cascade,
+  state dm_member_state not null default 'active',
+  last_read_at timestamptz default 'epoch',
+  created_at timestamptz default now(),
+  primary key (conversation_id, user_id)
+);
+
+-- messages
+create table if not exists dm_messages (
+  id uuid primary key default gen_random_uuid(),
+  conversation_id uuid not null references dm_conversations(id) on delete cascade,
+  author_id uuid not null references auth.users(id) on delete cascade,
+  body text not null check (char_length(body) <= 4000),
+  attachments jsonb not null default '[]'::jsonb,
+  created_at timestamptz default now(),
+  is_deleted boolean not null default false
+);
+create index if not exists idx_dm_messages_conv_created on dm_messages(conversation_id, created_at asc);
+
+-- handy index for member lookups
+create index if not exists idx_dm_members_user_created on dm_members(user_id, created_at desc);
+
+-- notifications extension (add 2 new types if not present)
+do $$ begin
+  if not exists (select 1 from pg_type where typname='notif_type') then
+    create type notif_type as enum ('follow','follow_request','follow_accept','post_like','post_comment','comment_reply','dm_message','dm_request');
+  elsif not exists (select 1 from pg_enum where enumlabel='dm_message' and enumtypid='notif_type'::regtype) then
+    alter type notif_type add value if not exists 'dm_message';
+    alter type notif_type add value if not exists 'dm_request';
+  end if;
+end $$;
+
+-- RLS
+alter table dm_conversations enable row level security;
+alter table dm_members enable row level security;
+alter table dm_messages enable row level security;
+
+-- Only participants can see their conversation rows
+do $$ begin
+  if not exists (select 1 from pg_policies where tablename='dm_conversations' and policyname='dm_conv_select_participant') then
+    create policy dm_conv_select_participant on dm_conversations for select using (
+      exists (select 1 from dm_members m where m.conversation_id = id and m.user_id = auth.uid())
+    );
+  end if;
+end $$;
+
+-- Members: user can read/update their own membership row; inserts happen via RPC
+do $$ begin
+  if not exists (select 1 from pg_policies where tablename='dm_members' and policyname='dm_members_select_own') then
+    create policy dm_members_select_own on dm_members for select using (user_id = auth.uid());
+  end if;
+  if not exists (select 1 from pg_policies where tablename='dm_members' and policyname='dm_members_update_own') then
+    create policy dm_members_update_own on dm_members for update using (user_id = auth.uid()) with check (user_id = auth.uid());
+  end if;
+end $$;
+
+-- Messages: only participants can read; only participant authors can insert/update their messages
+do $$ begin
+  if not exists (select 1 from pg_policies where tablename='dm_messages' and policyname='dm_messages_select_conv_participant') then
+    create policy dm_messages_select_conv_participant on dm_messages for select using (
+      exists (select 1 from dm_members m where m.conversation_id = dm_messages.conversation_id and m.user_id = auth.uid())
+    );
+  end if;
+  if not exists (select 1 from pg_policies where tablename='dm_messages' and policyname='dm_messages_insert_author_member') then
+    create policy dm_messages_insert_author_member on dm_messages for insert with check (
+      author_id = auth.uid()
+      and exists (select 1 from dm_members m where m.conversation_id = dm_messages.conversation_id and m.user_id = auth.uid() and m.state in ('active','pending'))
+    );
+  end if;
+  if not exists (select 1 from pg_policies where tablename='dm_messages' and policyname='dm_messages_update_own') then
+    create policy dm_messages_update_own on dm_messages for update using (author_id = auth.uid()) with check (author_id = auth.uid());
+  end if;
+end $$;
+
+-- RPC functions
+
+-- Start or fetch a conversation and handle request vs active.
+create or replace function dm_start(p_me uuid, p_other uuid)
+returns uuid
+language plpgsql
+security definer
+as $$
+declare
+  conv uuid;
+  me_state dm_member_state := 'active';
+  other_state dm_member_state := 'active';
+  other_private boolean := false;
+begin
+  if p_me = p_other then
+    raise exception 'cannot_dm_self';
+  end if;
+
+  -- blocks either direction
+  if exists(select 1 from blocks b where (b.blocker_id=p_me and b.blocked_id=p_other) or (b.blocker_id=p_other and b.blocked_id=p_me)) then
+    raise exception 'blocked';
+  end if;
+
+  -- check privacy (if private and you do NOT follow them → request)
+  select coalesce(us.is_private,false) into other_private from user_settings us where us.user_id = p_other;
+  if other_private and not exists (select 1 from follows f where f.follower_id = p_me and f.followee_id = p_other) then
+    me_state := 'active';
+    other_state := 'pending';
+  end if;
+
+  -- existing conversation?
+  select c.id into conv
+  from dm_conversations c
+  join dm_members m1 on m1.conversation_id=c.id and m1.user_id=p_me
+  join dm_members m2 on m2.conversation_id=c.id and m2.user_id=p_other
+  limit 1;
+
+  if conv is null then
+    insert into dm_conversations default values returning id into conv;
+    insert into dm_members(conversation_id,user_id,state) values (conv,p_me,me_state), (conv,p_other,other_state);
+    -- notif if request
+    if other_state='pending' then
+      perform create_notification(p_other, p_me, 'dm_request', null, null, '{}'::jsonb);
+    end if;
+  end if;
+
+  return conv;
+end;
+$$;
+
+grant execute on function dm_start(uuid,uuid) to anon, authenticated;
+
+-- Accept or decline request (target only)
+create or replace function dm_set_request(p_me uuid, p_conversation uuid, p_action text) returns void
+language plpgsql security definer as $$
+begin
+  -- only the pending member can act
+  if not exists (select 1 from dm_members where conversation_id=p_conversation and user_id=p_me and state='pending') then
+    raise exception 'no_pending_request';
+  end if;
+
+  if p_action='accept' then
+    update dm_members set state='active' where conversation_id=p_conversation and user_id=p_me;
+  elsif p_action='decline' then
+    delete from dm_members where conversation_id=p_conversation and user_id=p_me;
+    -- if other member alone, delete conversation
+    delete from dm_conversations c
+      where c.id=p_conversation and not exists (select 1 from dm_members m where m.conversation_id=c.id);
+  else
+    raise exception 'bad_action';
+  end if;
+end;
+$$;
+
+grant execute on function dm_set_request(uuid,uuid,text) to anon, authenticated;
+
+-- Update last_read_at
+create or replace function dm_mark_read(p_me uuid, p_conversation uuid) returns void
+language sql security definer as $$
+  update dm_members set last_read_at=now()
+  where conversation_id=p_conversation and user_id=p_me;
+$$;
+
+grant execute on function dm_mark_read(uuid,uuid) to anon, authenticated;


### PR DESCRIPTION
## Summary
- add SQL schema, RLS and RPC helpers for DM conversations
- scaffold client helpers, pages and components for messaging and requests
- document DM flows and API helpers

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any and existing warnings)


------
https://chatgpt.com/codex/tasks/task_e_68b0b4e692f083278e57a505ee4857b2