### PR TITLE
Add push notifications, link previews, and collections API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^0.9.3",
+        "web-push": "^3.6.7",
         "zod": "^3.23.8"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
+    "web-push": "^3.6.7",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/src/app/api/collections/[id]/add/route.ts
+++ b/src/app/api/collections/[id]/add/route.ts
@@ -1,0 +1,26 @@
+// app/api/collections/[id]/add/route.ts
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+
+function supabase() {
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: { get: (n: string) => cookies().get(n)?.value, set() {}, remove() {} } }
+  );
+}
+
+export async function POST(req: Request, ctx: { params: { id: string } }) {
+  const { postId } = await req.json().catch(() => ({}));
+  if (!postId) return NextResponse.json({ error: 'bad_request' }, { status: 400 });
+
+  const sb = supabase();
+  const { data: u } = await sb.auth.getUser();
+  if (!u?.user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const { error } = await sb.from('collection_posts').insert({ collection_id: ctx.params.id, post_id: postId });
+  if (error) return NextResponse.json({ error: 'add_failed' }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}
+

--- a/src/app/api/collections/[id]/remove/route.ts
+++ b/src/app/api/collections/[id]/remove/route.ts
@@ -1,0 +1,30 @@
+// app/api/collections/[id]/remove/route.ts
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+
+function supabase() {
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: { get: (n: string) => cookies().get(n)?.value, set() {}, remove() {} } }
+  );
+}
+
+export async function DELETE(req: Request, ctx: { params: { id: string } }) {
+  const { postId } = await req.json().catch(() => ({}));
+  if (!postId) return NextResponse.json({ error: 'bad_request' }, { status: 400 });
+
+  const sb = supabase();
+  const { data: u } = await sb.auth.getUser();
+  if (!u?.user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const { error } = await sb.from('collection_posts')
+    .delete()
+    .eq('collection_id', ctx.params.id)
+    .eq('post_id', postId);
+
+  if (error) return NextResponse.json({ error: 'remove_failed' }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}
+

--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -1,0 +1,47 @@
+// app/api/collections/[id]/route.ts
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+
+function supabase() {
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: { get: (n: string) => cookies().get(n)?.value, set() {}, remove() {} } }
+  );
+}
+
+export async function GET(_req: Request, ctx: { params: { id: string } }) {
+  const sb = supabase();
+  const { data: u } = await sb.auth.getUser();
+  if (!u?.user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  // list posts in collection with basic pagination (cursor optional later)
+  const { data, error } = await sb
+    .from('collection_posts')
+    .select('post_id, created_at, collections!inner(id, owner_id, is_private)')
+    .eq('collection_id', ctx.params.id)
+    .order('created_at', { ascending: false })
+    .limit(50);
+
+  if (error) return NextResponse.json({ error: 'fetch_failed' }, { status: 500 });
+  return NextResponse.json({ items: data });
+}
+
+export async function PUT(req: Request, ctx: { params: { id: string } }) {
+  const { name, isPrivate } = await req.json().catch(() => ({}));
+  const sb = supabase();
+  const { data: u } = await sb.auth.getUser();
+  if (!u?.user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const updates: any = {};
+  if (typeof name === 'string' && name.trim()) updates.name = name.trim();
+  if (typeof isPrivate === 'boolean') updates.is_private = isPrivate;
+
+  if (!Object.keys(updates).length) return NextResponse.json({ error: 'bad_request' }, { status: 400 });
+
+  const { error } = await sb.from('collections').update(updates).eq('id', ctx.params.id);
+  if (error) return NextResponse.json({ error: 'update_failed' }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}
+

--- a/src/app/api/collections/route.ts
+++ b/src/app/api/collections/route.ts
@@ -1,0 +1,30 @@
+// app/api/collections/route.ts
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+
+function supabase() {
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: { get: (n: string) => cookies().get(n)?.value, set() {}, remove() {} } }
+  );
+}
+
+export async function POST(req: Request) {
+  const { name, isPrivate } = await req.json().catch(() => ({}));
+  if (!name || typeof name !== 'string' || name.length > 80) {
+    return NextResponse.json({ error: 'bad_request' }, { status: 400 });
+  }
+  const sb = supabase();
+  const { data: u } = await sb.auth.getUser();
+  if (!u?.user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const { data, error } = await sb.from('collections')
+    .insert({ owner_id: u.user.id, name: name.trim(), is_private: !!isPrivate })
+    .select('id, name, is_private').single();
+
+  if (error) return NextResponse.json({ error: 'create_failed' }, { status: 500 });
+  return NextResponse.json({ collection: data });
+}
+

--- a/src/app/api/save/route.ts
+++ b/src/app/api/save/route.ts
@@ -1,0 +1,40 @@
+// app/api/save/route.ts
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+
+function supabase() {
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: { get: (n: string) => cookies().get(n)?.value, set() {}, remove() {} } }
+  );
+}
+
+export async function POST(req: Request) {
+  const { postId } = await req.json().catch(() => ({}));
+  if (!postId) return NextResponse.json({ error: 'bad_request' }, { status: 400 });
+
+  const sb = supabase();
+  const { data: u } = await sb.auth.getUser();
+  if (!u?.user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const { error } = await sb.from('saved_posts').upsert({ user_id: u.user.id, post_id: postId });
+  if (error) return NextResponse.json({ error: 'save_failed' }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(req: Request) {
+  const body = await req.json().catch(() => ({}));
+  const postId = body?.postId;
+  if (!postId) return NextResponse.json({ error: 'bad_request' }, { status: 400 });
+
+  const sb = supabase();
+  const { data: u } = await sb.auth.getUser();
+  if (!u?.user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const { error } = await sb.from('saved_posts').delete().eq('user_id', u.user.id).eq('post_id', postId);
+  if (error) return NextResponse.json({ error: 'unsave_failed' }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}
+

--- a/src/app/api/unfurl/route.ts
+++ b/src/app/api/unfurl/route.ts
@@ -1,0 +1,126 @@
+// app/api/unfurl/route.ts
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const BYTES_CAP = 1_000_000; // 1MB
+const FETCH_TIMEOUT = 5000;
+
+function supabase() {
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get: (name: string) => cookies().get(name)?.value,
+        set() {},
+        remove() {},
+      },
+    }
+  );
+}
+
+function isHttpUrl(u: string) {
+  try {
+    const url = new URL(u);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch { return false; }
+}
+
+function parseMeta(html: string) {
+  // lightweight OG/Twitter extractor
+  const get = (prop: string) => {
+    const re = new RegExp(`<meta[^>]+(?:property|name)=["']${prop}["'][^>]+content=["']([^"']+)["'][^>]*>`, 'i');
+    const m = html.match(re);
+    return m?.[1] || '';
+  };
+  const title = get('og:title') || get('twitter:title') || (html.match(/<title[^>]*>([^<]+)<\/title>/i)?.[1] || '');
+  const description = get('og:description') || get('twitter:description') || '';
+  const image = get('og:image') || get('twitter:image') || '';
+  const site = get('og:site_name') || get('twitter:site') || '';
+  return { title: title.trim(), description: description.trim(), image_url: image.trim(), site_name: site.trim() };
+}
+
+async function fetchWithCaps(url: string) {
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), FETCH_TIMEOUT);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        'user-agent': 'UnderPinesBot/1.0 (+https://underpines.app)',
+        'accept': 'text/html,application/xhtml+xml',
+      },
+      cache: 'no-store',
+    });
+    const reader = res.body?.getReader();
+    let received = 0;
+    let chunks: Uint8Array[] = [];
+    if (reader) {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        if (value) {
+          received += value.byteLength;
+          if (received > BYTES_CAP) throw new Error('too_large');
+          chunks.push(value);
+        }
+      }
+    }
+    const html = Buffer.concat(chunks).toString('utf8');
+    return { ok: true, status: res.status, html };
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+export async function POST(req: Request) {
+  const { url } = await req.json().catch(() => ({}));
+  if (!url || typeof url !== 'string' || !isHttpUrl(url) || url.length > 2048) {
+    return NextResponse.json({ error: 'bad_url' }, { status: 400 });
+  }
+
+  const sb = supabase();
+
+  // cache hit?
+  const { data: cached } = await sb
+    .from('link_previews')
+    .select('*')
+    .eq('url', url)
+    .maybeSingle();
+
+  if (cached && cached.fetched_at && Date.now() - new Date(cached.fetched_at).getTime() < ONE_DAY_MS) {
+    return NextResponse.json(cached, { headers: { 'Cache-Control': 'public, max-age=300' } });
+  }
+
+  try {
+    const res = await fetchWithCaps(url);
+    const meta = res.ok ? parseMeta(res.html) : { title: '', description: '', image_url: '', site_name: '' };
+    const row = {
+      url,
+      title: meta.title,
+      description: meta.description,
+      image_url: meta.image_url,
+      site_name: meta.site_name,
+      fetched_at: new Date().toISOString(),
+      status: res.ok ? 200 : 500,
+    };
+
+    await sb.from('link_previews').upsert(row);
+    return NextResponse.json(row, { headers: { 'Cache-Control': 'public, max-age=300' } });
+  } catch (e: any) {
+    const row = {
+      url,
+      title: '',
+      description: '',
+      image_url: '',
+      site_name: '',
+      fetched_at: new Date().toISOString(),
+      status: e?.message === 'too_large' ? 413 : 408,
+    };
+    await sb.from('link_previews').upsert(row);
+    return NextResponse.json(row, { headers: { 'Cache-Control': 'public, max-age=120' } });
+  }
+}
+

--- a/src/components/post/LinkPreviewCard.tsx
+++ b/src/components/post/LinkPreviewCard.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Image from 'next/image';
+
+type Props = {
+  url: string;
+  title?: string;
+  description?: string;
+  image_url?: string;
+  site_name?: string;
+  compact?: boolean;
+};
+
+export default function LinkPreviewCard({ url, title, description, image_url, site_name, compact }: Props) {
+  const hostname = (() => {
+    try { return new URL(url).hostname.replace(/^www\./, ''); } catch { return ''; }
+  })();
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="block rounded-lg overflow-hidden border border-white/10 bg-background-panel hover:bg-white/5 transition"
+    >
+      {image_url && !compact && (
+        <div className="relative w-full pt-[52%]">
+          <Image
+            src={image_url}
+            alt=""
+            fill
+            sizes="(max-width: 768px) 100vw, 640px"
+            className="object-cover"
+          />
+        </div>
+      )}
+      <div className="p-3">
+        <div className="text-xs text-text-light/60">{site_name || hostname}</div>
+        {title && <div className="mt-1 text-sm font-semibold text-text-light line-clamp-2">{title}</div>}
+        {description && <div className="mt-1 text-xs text-text-light/70 line-clamp-2">{description}</div>}
+      </div>
+    </a>
+  );
+}
+

--- a/src/lib/push/send.ts
+++ b/src/lib/push/send.ts
@@ -1,0 +1,99 @@
+// lib/push/send.ts
+// npm i web-push
+import webpush from 'web-push';
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const VAPID_PUBLIC_KEY = process.env.VAPID_PUBLIC_KEY!;
+const VAPID_PRIVATE_KEY = process.env.VAPID_PRIVATE_KEY!;
+const APP_ORIGIN = process.env.NEXT_PUBLIC_APP_ORIGIN || 'https://underpines.app';
+
+if (!SUPABASE_SERVICE_ROLE_KEY) {
+  console.warn('[push] Missing SUPABASE_SERVICE_ROLE_KEY — push sending will be disabled.');
+}
+
+webpush.setVapidDetails(`mailto:hello@underpines.app`, VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY);
+
+const admin = SUPABASE_SERVICE_ROLE_KEY
+  ? createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, { auth: { persistSession: false } })
+  : null;
+
+type PushPayload = {
+  title: string;
+  body: string;
+  deeplink?: string;
+  icon?: string;
+};
+
+function withinQuietHours(now: Date, start?: string | null, end?: string | null): boolean {
+  if (!start || !end) return false;
+  const [sh, sm] = start.split(':').map(Number);
+  const [eh, em] = end.split(':').map(Number);
+  const mins = now.getUTCHours() * 60 + now.getUTCMinutes();
+  const s = sh * 60 + sm;
+  const e = eh * 60 + em;
+  // quiet may wrap past midnight
+  return s <= e ? (mins >= s && mins <= e) : (mins >= s || mins <= e);
+}
+
+export async function sendPush(userId: string, payload: PushPayload, category?: 'follow'|'requests'|'comments'|'likes'|'dms') {
+  if (!admin || !SUPABASE_SERVICE_ROLE_KEY) return;
+
+  // read settings
+  const { data: settings } = await admin
+    .from('user_notification_settings')
+    .select('push_follow, push_requests, push_comments, push_likes, push_dms, quiet_start, quiet_end')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  // category toggle
+  if (settings) {
+    const allow =
+      (category === 'follow'   && settings.push_follow)   ||
+      (category === 'requests' && settings.push_requests) ||
+      (category === 'comments' && settings.push_comments) ||
+      (category === 'likes'    && settings.push_likes)    ||
+      (category === 'dms'      && settings.push_dms);
+    if (category && allow === false) return;
+    const now = new Date();
+    if (withinQuietHours(now, settings.quiet_start, settings.quiet_end)) return;
+  }
+
+  // subscriptions
+  const { data: subs } = await admin
+    .from('user_push_subscriptions')
+    .select('id, endpoint, p256dh, auth')
+    .eq('user_id', userId);
+
+  if (!subs || subs.length === 0) return;
+
+  const notification = {
+    title: payload.title,
+    body: payload.body,
+    icon: payload.icon || `${APP_ORIGIN}/icons/icon-192.png`,
+    data: { deeplink: payload.deeplink || APP_ORIGIN },
+  };
+
+  await Promise.all(
+    subs.map(async (s) => {
+      try {
+        await webpush.sendNotification(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          { endpoint: s.endpoint, keys: { p256dh: s.p256dh, auth: s.auth } } as any,
+          JSON.stringify(notification),
+          { TTL: 60 }
+        );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (err: any) {
+        // prune expired endpoints
+        if (err?.statusCode === 404 || err?.statusCode === 410) {
+          await admin.from('user_push_subscriptions').delete().eq('id', s.id);
+        } else {
+          console.error('[push] send error', err?.statusCode || err?.message);
+        }
+      }
+    })
+  );
+}
+


### PR DESCRIPTION
## Summary
- add server util for sending web push notifications
- implement link unfurling cache API and client preview rendering
- support saving posts and managing collections via new API routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 6 errors, 12 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c2aa3ddc832793339a9667ee6f1a