### PR TITLE
Add production readiness checklist and preflight script

### DIFF
--- a/PRODUCTION_CHECKLIST.md
+++ b/PRODUCTION_CHECKLIST.md
@@ -1,0 +1,61 @@
+# Production Readiness Checklist
+
+Use this issue to track tasks for hardening Under Pines for production.
+
+## 1. Security & Privacy
+- [ ] RLS audit: enable RLS and sane policies on every public table.
+- [ ] Review security-definer functions and ensure each sets a safe `search_path` and validates auth/ownership.
+- [ ] Keep `SUPABASE_SERVICE_ROLE_KEY` server-only and rotate VAPID and anon keys.
+- [ ] Re-enable email confirmation, add password reset, consider TOTP 2FA, and configure SMTP with SPF/DKIM/DMARC.
+- [ ] For POST/PUT/DELETE routes, enforce same-origin and JSON content type.
+- [ ] Rate-limit write endpoints.
+- [ ] Add strict security headers (CSP, X-Frame-Options, Referrer-Policy, Permissions-Policy).
+- [ ] Throttle signups and new-posts with CAPTCHA and cooldowns.
+
+## 2. Reliability & Scalability
+- [ ] Enable automated DB backups and test restores; mirror storage off-site.
+- [ ] One migration per change, forward-only; plan for rollbacks via feature flags.
+- [ ] Add missing indexes and set a global `statement_timeout`.
+- [ ] Use connection pooling and avoid N+1 queries.
+- [ ] Serve media via CDN with long cache-control; schedule GC for orphans.
+- [ ] Schedule jobs for pruning old previews, deleting stale requests, and compacting analytics.
+
+## 3. Observability & Ops
+- [ ] Add Sentry to frontend and API routes.
+- [ ] Log non-200 API responses with structured data (user_id, route, latency, code).
+- [ ] Provide `/api/health` and set up external uptime monitoring and alerts.
+- [ ] Implement feature flags to disable signups, posting, DMs, push, and enable read-only mode.
+- [ ] Define SLOs and surface them on an admin dashboard.
+
+## 4. Compliance & Policy
+- [ ] Publish Privacy Policy and Terms of Service in footer, signup, and settings.
+- [ ] Implement `/api/me/export` and `/api/me/delete` for data rights; soft-delete then purge media.
+- [ ] Add age gating or block users under 13.
+- [ ] Write content policy and DMCA process with a takedown contact.
+
+## 5. Performance & UX
+- [ ] Monitor Next.js bundle size and code-split heavy pages.
+- [ ] Cache API GETs (SWR, ETag) and increase CDN TTLs where stable.
+- [ ] Ensure accessibility: keyboard nav, focus rings, alt text, color contrast.
+- [ ] Test PWA on iOS including push permission and notification click-through.
+
+## 6. Testing
+- [ ] Add unit tests for utils and helpers.
+- [ ] Add integration tests for API routes with local Postgres or Supabase preview project.
+- [ ] Add E2E tests for critical flows (signup, posts, follows, DMs, notifications, etc.).
+- [ ] Load test with 200–1k concurrent users and monitor DB and latency.
+
+## 7. Final Production Setup
+- [ ] Configure custom domain with HTTPS and redirects.
+- [ ] Configure email sender domain with SPF/DKIM/DMARC and re-enable confirmation.
+- [ ] Separate prod/stage/dev environments and Supabase projects.
+- [ ] Rotate all keys and secure dashboard access with SSO/2FA.
+- [ ] Verify all tables have RLS enabled.
+- [ ] Run restore drill and media GC.
+- [ ] Ensure Sentry and uptime monitors show green for 24–48h.
+- [ ] Test feature flags (READ_ONLY, DISABLE_DMS, DISABLE_SIGNUPS).
+- [ ] Publish legal pages and monitor report/takedown mailbox.
+- [ ] Lighthouse score: Performance ≥85, A11y ≥90 on key pages.
+
+## Quick Hardening Snippets
+See repo `scripts/preflight.js` for RLS and SECURITY DEFINER checks.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "preflight": "node scripts/preflight.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -82,6 +83,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "pg": "^8.11.3"
   }
 }

--- a/scripts/preflight.js
+++ b/scripts/preflight.js
@@ -1,0 +1,42 @@
+import { Client } from 'pg';
+
+const connectionString = process.env.DATABASE_URL;
+
+if (!connectionString) {
+  console.error('DATABASE_URL is not set');
+  process.exit(1);
+}
+
+const client = new Client({ connectionString });
+
+async function main() {
+  try {
+    await client.connect();
+    const rls = await client.query(`
+      select relname as table
+      from pg_class c
+      join pg_namespace n on n.oid = c.relnamespace
+      where n.nspname='public' and c.relkind='r' and c.relrowsecurity = false;
+    `);
+    if (rls.rows.length > 0) {
+      console.error('Tables without RLS:', rls.rows.map(r => r.table).join(', '));
+      process.exit(1);
+    }
+    const definer = await client.query(`
+      select proname from pg_proc p join pg_namespace n on n.oid=p.pronamespace
+      where n.nspname='public' and prosecdef = true;
+    `);
+    if (definer.rows.length > 0) {
+      console.error('Security definer functions found:', definer.rows.map(r => r.proname).join(', '));
+      process.exit(1);
+    }
+    console.log('RLS and SECURITY DEFINER checks passed');
+  } catch (err) {
+    console.error('Preflight check failed:', err);
+    process.exit(1);
+  } finally {
+    await client.end();
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- Add `PRODUCTION_CHECKLIST.md` with security, reliability, and ops tasks for launch
- Introduce `scripts/preflight.js` to fail CI when RLS or SECURITY DEFINER issues are found
- Wire up `preflight` npm script and note `pg` dev dependency

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: 6 errors, 12 warnings)*
- `node scripts/preflight.js` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_68b0c88d80c08327822fa8dcf7025106