### PR TITLE
Add responsive navigation with unread counts

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-router-dom": "^6.26.2",
     "recharts": "^2.12.7",
     "sonner": "^1.5.0",
+    "swr": "^2.2.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,0 +1,13 @@
+import { createClient } from '@/lib/supabase/server';
+import AppShell from '@/components/nav/AppShell';
+
+export default async function AppLayout({ children }: { children: React.ReactNode }) {
+  const sb = createClient();
+  const { data: u } = await sb.auth.getUser();
+  let meUsername: string | undefined;
+  if (u?.user) {
+    const { data: p } = await sb.from('profiles').select('username').eq('id', u.user.id).maybeSingle();
+    meUsername = p?.username || undefined;
+  }
+  return <AppShell meUsername={meUsername}>{children}</AppShell>;
+}

--- a/src/app/api/dm/unread-count/route.ts
+++ b/src/app/api/dm/unread-count/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function GET() {
+  const sb = createClient();
+  const { data: u } = await sb.auth.getUser();
+  if (!u?.user) return NextResponse.json({ count: 0 });
+  const { data, error } = await sb.rpc('dm_unread_count', { p_me: u.user.id });
+  if (error) return NextResponse.json({ count: 0 });
+  return NextResponse.json({ count: data ?? 0 });
+}

--- a/src/components/nav/AppHeader.tsx
+++ b/src/components/nav/AppHeader.tsx
@@ -1,0 +1,34 @@
+'use client';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { SparkIcon } from './icons';
+
+export default function AppHeader() {
+  const p = usePathname();
+  const showSearch = !p.startsWith('/messages') && !p.startsWith('/compose');
+
+  return (
+    <header className="sticky top-0 z-30 bg-[#0B1C13]/80 backdrop-blur border-b border-white/10">
+      <div className="mx-auto max-w-3xl px-3 h-14 flex items-center gap-3">
+        <Link href="/" className="lg:hidden text-base font-semibold">🌲 Under Pines</Link>
+        {showSearch && (
+          <div className="flex-1">
+            {/* Replace with your existing PeopleTypeahead; this is a placeholder input */}
+            <input
+              className="w-full h-9 px-3 rounded-md bg-white/5 placeholder:text-white/50 focus:outline-none focus:ring-2 focus:ring-white/20"
+              placeholder="Search people and tags…"
+              aria-label="Search"
+              onFocus={(e)=>{ /* optionally open your search drawer */ }}
+            />
+          </div>
+        )}
+        <Link href="/embers" className="hidden sm:inline-flex items-center gap-2 h-9 px-3 rounded-md bg-white/10 hover:bg-white/15">
+          <SparkIcon /><span className="text-sm">Embers</span>
+        </Link>
+        <Link href="/compose" className="hidden sm:inline-flex items-center justify-center h-9 px-3 rounded-md bg-background-sand text-black text-sm font-medium">
+          Create
+        </Link>
+      </div>
+    </header>
+  );
+}

--- a/src/components/nav/AppShell.tsx
+++ b/src/components/nav/AppShell.tsx
@@ -1,0 +1,22 @@
+'use client';
+import { ReactNode } from 'react';
+import DesktopSidebar from './DesktopSidebar';
+import MobileTabBar from './MobileTabBar';
+import AppHeader from './AppHeader';
+
+export default function AppShell({ children, meUsername }: { children: ReactNode; meUsername?: string }) {
+  return (
+    <div className="min-h-screen bg-[#0B1C13] text-white">
+      <div className="mx-auto max-w-7xl flex">
+        <DesktopSidebar meUsername={meUsername} />
+        <main className="flex-1 min-w-0">
+          <AppHeader />
+          <div className="mx-auto max-w-3xl px-3 py-4">
+            {children}
+          </div>
+        </main>
+      </div>
+      <MobileTabBar />
+    </div>
+  );
+}

--- a/src/components/nav/DesktopSidebar.tsx
+++ b/src/components/nav/DesktopSidebar.tsx
@@ -1,0 +1,31 @@
+'use client';
+import NavItem from './NavItem';
+import { HomeIcon, SearchIcon, SparkIcon, BellIcon, DmIcon, GroupsIcon, SaveIcon, UserIcon } from './icons';
+import { useUnread } from './useUnread';
+import Link from 'next/link';
+
+export default function DesktopSidebar({ meUsername }: { meUsername?: string }) {
+  const { notifCount, dmCount } = useUnread();
+
+  return (
+    <aside className="hidden lg:flex lg:flex-col lg:w-64 lg:shrink-0 border-r border-white/10 h-screen sticky top-0">
+      <div className="px-4 py-5 text-lg font-semibold">🌲 Under Pines</div>
+      <nav className="px-2 space-y-1">
+        <NavItem href="/"           icon={HomeIcon}   label="Home" exact />
+        <NavItem href="/search"     icon={SearchIcon} label="Search" />
+        <NavItem href="/embers"     icon={SparkIcon}  label="Embers" />
+        <NavItem href="/groups"     icon={GroupsIcon} label="Groups" />
+        <NavItem href="/saved"      icon={SaveIcon}   label="Saved" />
+        <NavItem href="/notifications" icon={BellIcon} label="Notifications" badge={notifCount} />
+        <NavItem href="/messages"   icon={DmIcon}     label="Messages" badge={dmCount} />
+      </nav>
+
+      <div className="mt-auto px-2 py-4">
+        <Link href="/compose" className="inline-flex items-center justify-center w-full h-10 rounded-md bg-background-sand text-black text-sm font-medium">
+          Create
+        </Link>
+        <NavItem href={meUsername ? `/@${meUsername}` : '/me'} icon={UserIcon} label="Profile" />
+      </div>
+    </aside>
+  );
+}

--- a/src/components/nav/MobileTabBar.tsx
+++ b/src/components/nav/MobileTabBar.tsx
@@ -1,0 +1,50 @@
+'use client';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { HomeIcon, SearchIcon, SparkIcon, BellIcon, DmIcon, PlusIcon } from './icons';
+import NavBadge from './NavBadge';
+import { useUnread } from './useUnread';
+import clsx from 'clsx';
+import type { ComponentType, SVGProps } from 'react';
+
+export default function MobileTabBar() {
+  const { notifCount, dmCount } = useUnread();
+  const p = usePathname();
+
+  const Item = ({ href, Icon }: { href: string; Icon: ComponentType<SVGProps<SVGSVGElement>> }) => {
+    const active = p === href || p.startsWith(href);
+    return (
+      <Link href={href} className={clsx('flex-1 grid place-items-center h-12', active ? 'text-white' : 'text-white/70')}>
+        <Icon />
+        <span className="sr-only">{href}</span>
+        {href === '/notifications' && <div className="absolute top-1 right-[20%]"><NavBadge count={notifCount}/></div>}
+        {href === '/messages'      && <div className="absolute top-1 right-[5%]"><NavBadge count={dmCount}/></div>}
+      </Link>
+    );
+  };
+
+  return (
+    <div className="lg:hidden">
+      <div className="fixed bottom-0 inset-x-0 border-t border-white/10 bg-[#0B1C13]/95 backdrop-blur z-40">
+        <div className="relative flex items-center">
+          <Item href="/"             Icon={HomeIcon}/>
+          <Item href="/search"       Icon={SearchIcon}/>
+          <div className="relative -mt-6 flex-1 grid place-items-center">
+            <Link href="/compose" className="grid place-items-center h-12 w-12 rounded-full bg-background-sand text-black shadow-md">
+              <PlusIcon />
+              <span className="sr-only">Compose</span>
+            </Link>
+          </div>
+          <Item href="/notifications" Icon={BellIcon}/>
+          <Item href="/messages"      Icon={DmIcon}/>
+        </div>
+      </div>
+
+      {/* Optional quick access to Embers */}
+      <Link href="/embers" className="fixed right-4 bottom-20 grid place-items-center h-10 w-10 rounded-full bg-white/10 text-white/90 backdrop-blur z-40">
+        <SparkIcon />
+        <span className="sr-only">Embers</span>
+      </Link>
+    </div>
+  );
+}

--- a/src/components/nav/NavBadge.tsx
+++ b/src/components/nav/NavBadge.tsx
@@ -1,0 +1,9 @@
+'use client';
+export default function NavBadge({ count }: { count: number }) {
+  if (!count) return null;
+  return (
+    <span className="ml-2 inline-flex min-w-[18px] h-[18px] px-1 rounded-full bg-accent-warm text-black text-[11px] leading-[18px] justify-center">
+      {count > 99 ? '99+' : count}
+    </span>
+  );
+}

--- a/src/components/nav/NavItem.tsx
+++ b/src/components/nav/NavItem.tsx
@@ -1,0 +1,27 @@
+'use client';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import NavBadge from './NavBadge';
+import clsx from 'clsx';
+import type { ComponentType, SVGProps } from 'react';
+
+export default function NavItem({
+  href, icon: Icon, label, badge = 0, exact = false
+}: { href: string; icon: ComponentType<SVGProps<SVGSVGElement>>; label: string; badge?: number; exact?: boolean }) {
+  const pathname = usePathname();
+  const active = exact ? pathname === href : pathname.startsWith(href);
+  return (
+    <Link
+      href={href}
+      aria-current={active ? 'page' : undefined}
+      className={clsx(
+        'flex items-center gap-3 px-3 py-2 rounded-md transition',
+        active ? 'bg-white/10 text-white' : 'text-white/80 hover:bg-white/5'
+      )}
+    >
+      <Icon />
+      <span className="text-sm">{label}</span>
+      {!!badge && <NavBadge count={badge} />}
+    </Link>
+  );
+}

--- a/src/components/nav/icons.tsx
+++ b/src/components/nav/icons.tsx
@@ -1,0 +1,11 @@
+import type { SVGProps } from 'react';
+
+export const HomeIcon = (p: SVGProps<SVGSVGElement>) => (<svg viewBox="0 0 24 24" className="h-5 w-5" {...p}><path fill="currentColor" d="M12 3 2 12h3v8h6v-5h2v5h6v-8h3z"/></svg>);
+export const SearchIcon = (p: SVGProps<SVGSVGElement>) => (<svg viewBox="0 0 24 24" className="h-5 w-5" {...p}><path fill="currentColor" d="M10 2a8 8 0 1 1 0 16 8 8 0 0 1 0-16Zm11 19-5.4-5.4"/></svg>);
+export const SparkIcon = (p: SVGProps<SVGSVGElement>) => (<svg viewBox="0 0 24 24" className="h-5 w-5" {...p}><path fill="currentColor" d="M12 2l2 6 6 2-6 2-2 6-2-6-6-2 6-2z"/></svg>);
+export const BellIcon = (p: SVGProps<SVGSVGElement>) => (<svg viewBox="0 0 24 24" className="h-5 w-5" {...p}><path fill="currentColor" d="M12 22a2 2 0 0 0 2-2H10a2 2 0 0 0 2 2Zm6-6V11a6 6 0 1 0-12 0v5L4 18v1h16v-1l-2-2Z"/></svg>);
+export const DmIcon = (p: SVGProps<SVGSVGElement>) => (<svg viewBox="0 0 24 24" className="h-5 w-5" {...p}><path fill="currentColor" d="M4 4h16v10H7l-3 3V4z"/></svg>);
+export const GroupsIcon = (p: SVGProps<SVGSVGElement>) => (<svg viewBox="0 0 24 24" className="h-5 w-5" {...p}><path fill="currentColor" d="M7 12a3 3 0 1 1 0-6 3 3 0 0 1 0 6Zm10 0a3 3 0 1 1 0-6 3 3 0 0 1 0 6ZM2 20c0-3 3-5 5-5s5 2 5 5H2Zm10 0c0-3 3-5 5-5s5 2 5 5H12Z"/></svg>);
+export const SaveIcon = (p: SVGProps<SVGSVGElement>) => (<svg viewBox="0 0 24 24" className="h-5 w-5" {...p}><path fill="currentColor" d="M6 2h12v20l-6-4-6 4V2z"/></svg>);
+export const UserIcon = (p: SVGProps<SVGSVGElement>) => (<svg viewBox="0 0 24 24" className="h-5 w-5" {...p}><path fill="currentColor" d="M12 12a5 5 0 1 0-5-5 5 5 0 0 0 5 5Zm0 2c-4 0-8 2-8 6h16c0-4-4-6-8-6Z"/></svg>);
+export const PlusIcon = (p: SVGProps<SVGSVGElement>) => (<svg viewBox="0 0 24 24" className="h-5 w-5" {...p}><path fill="currentColor" d="M11 5h2v6h6v2h-6v6h-2v-6H5v-2h6z"/></svg>);

--- a/src/components/nav/useUnread.ts
+++ b/src/components/nav/useUnread.ts
@@ -1,0 +1,13 @@
+'use client';
+import useSWR from 'swr';
+
+const fetcher = (u: string) => fetch(u, { cache: 'no-store' }).then(r => r.json());
+
+export function useUnread() {
+  const { data: notifs } = useSWR('/api/notifications/unread-count', fetcher, { refreshInterval: 30_000 });
+  const { data: dms }     = useSWR('/api/dm/unread-count',           fetcher, { refreshInterval: 30_000 });
+  return {
+    notifCount: notifs?.count ?? 0,
+    dmCount: dms?.count ?? 0,
+  };
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,0 +1,1 @@
+export { createServerSupabaseClient as createClient } from '../supabase-server';

--- a/supabase/migrations/20250822080000_dm_unread_count.sql
+++ b/supabase/migrations/20250822080000_dm_unread_count.sql
@@ -1,0 +1,19 @@
+-- Add an RPC that returns total unread DM messages for the current user.
+-- Counts messages authored by others where created_at > member.last_read_at.
+create or replace function dm_unread_count(p_me uuid)
+returns integer
+language sql
+stable
+as $$
+  with my_threads as (
+    select conversation_id, last_read_at
+    from dm_members
+    where user_id = p_me
+  ), unread as (
+    select count(*) as c
+    from dm_messages m
+    join my_threads t on t.conversation_id = m.conversation_id
+    where m.author_id <> p_me and m.created_at > t.last_read_at
+  )
+  select coalesce((select c from unread), 0);
+$$;


### PR DESCRIPTION
## Summary
- add Supabase RPC and API route to expose DM unread counts
- implement shared nav components with badges and hooks
- provide responsive app shell with desktop sidebar and mobile tab bar

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/pg)*
- `npm run lint` *(fails: 18 problems (6 errors, 12 warnings))*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0cb608fe88327af6fc02cb5d286bd