### PR TITLE
feat: add comment reactions

### DIFF
--- a/src/app/api/comments/[id]/react/route.ts
+++ b/src/app/api/comments/[id]/react/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+const ALLOWED = new Set(['👍','🔥','😂','😢','🤗','🤬','🙄'])
+
+export async function GET(_req: Request, { params }:{ params:{ id:string } }) {
+  const sb = createClient()
+  const { data } = await sb.rpc('comment_reaction_summary', { p_comment: params.id })
+  return NextResponse.json({ summary: data || [] })
+}
+
+export async function POST(req: Request, { params }:{ params:{ id:string } }) {
+  const { emoji } = await req.json().catch(()=>({}))
+  if (!ALLOWED.has(emoji)) return NextResponse.json({ error:'bad_reaction' }, { status:400 })
+
+  const sb = createClient()
+  const { data:u } = await sb.auth.getUser()
+  if (!u?.user) return NextResponse.json({ error:'unauthorized' }, { status:401 })
+
+  const { error } = await sb.from('comment_reactions').upsert({
+    comment_id: params.id, user_id: u.user.id, emoji
+  })
+  if (error) return NextResponse.json({ error:'react_failed' }, { status:500 })
+
+  const { data: summary } = await sb.rpc('comment_reaction_summary', { p_comment: params.id })
+  return NextResponse.json({ ok:true, summary: summary || [] })
+}
+
+export async function DELETE(_req: Request, { params }:{ params:{ id:string } }) {
+  const sb = createClient()
+  const { data:u } = await sb.auth.getUser()
+  if (!u?.user) return NextResponse.json({ error:'unauthorized' }, { status:401 })
+
+  await sb.from('comment_reactions').delete().eq('comment_id', params.id).eq('user_id', u.user.id)
+  const { data: summary } = await sb.rpc('comment_reaction_summary', { p_comment: params.id })
+  return NextResponse.json({ ok:true, summary: summary || [] })
+}

--- a/src/components/comments/CommentItem.tsx
+++ b/src/components/comments/CommentItem.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
-import { Heart, MessageSquare } from 'lucide-react'
+import { MessageSquare } from 'lucide-react'
 import { useAuth } from '@/contexts/AuthContext'
-import { Comment, createComment, toggleCommentLike } from '@/lib/comments'
+import { Comment, createComment } from '@/lib/comments'
 import { CommentComposer } from './CommentComposer'
+import CommentReactions from '@/components/reactions/CommentReactions'
 
 interface Props {
   comment: Comment
@@ -24,12 +25,7 @@ export function CommentItem({
 }: Props) {
   const { user } = useAuth()
   const [showReply, setShowReply] = useState(false)
-  const [likeData, setLikeData] = useState({ count: comment.like_count, didLike: false })
-
-  const handleLike = async () => {
-    const { like_count, did_like } = await toggleCommentLike(comment.id)
-    setLikeData({ count: like_count, didLike: did_like })
-  }
+  
 
   const handleReply = async (body: string) => {
     const reply = await createComment({ postId: comment.post_id, body, parentId: comment.id })
@@ -45,10 +41,7 @@ export function CommentItem({
           <div className="whitespace-pre-line text-sm">{comment.is_deleted ? 'Comment deleted' : comment.body}</div>
           {!comment.is_deleted && (
             <div className="flex gap-4 mt-2 text-sm text-muted-foreground">
-              <button onClick={handleLike} className="flex items-center gap-1" aria-label="Like comment">
-                <Heart className="h-4 w-4" fill={likeData.didLike ? 'currentColor' : 'none'} />
-                {likeData.count}
-              </button>
+              <CommentReactions commentId={comment.id} />
               {user && (
                 <button onClick={() => setShowReply(!showReply)} className="flex items-center gap-1" aria-label="Reply">
                   <MessageSquare className="h-4 w-4" /> Reply

--- a/src/components/reactions/CommentReactions.tsx
+++ b/src/components/reactions/CommentReactions.tsx
@@ -1,0 +1,68 @@
+'use client'
+import { useEffect, useRef, useState } from 'react'
+import ReactionBar from './ReactionBar'
+
+type Summary = { emoji: string; count: number }[]
+
+export default function CommentReactions({ commentId, initialSummary = [] as Summary }:{
+  commentId: string; initialSummary?: Summary
+}) {
+  const [summary, setSummary] = useState<Summary>(initialSummary)
+  const [open, setOpen] = useState(false)
+  const timer = useRef<any>(null)
+
+  useEffect(()=>{ (async()=>{
+    const r = await fetch(`/api/comments/${commentId}/react`)
+    const j = await r.json(); setSummary(j.summary || [])
+  })(); }, [commentId])
+
+  function onPointerDown(){ timer.current = setTimeout(()=>setOpen(true), 300) }
+  async function onPointerUp(){
+    if (timer.current) {
+      clearTimeout(timer.current)
+      await react('👍') // short tap defaults to 👍
+    }
+  }
+
+  async function react(emoji: string){
+    setOpen(false)
+    const r = await fetch(`/api/comments/${commentId}/react`, {
+      method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ emoji })
+    })
+    const j = await r.json(); if (j.summary) setSummary(j.summary)
+  }
+  async function clearReaction(){
+    const r = await fetch(`/api/comments/${commentId}/react`, { method:'DELETE' })
+    const j = await r.json(); if (j.summary) setSummary(j.summary)
+  }
+
+  return (
+    <div className="relative inline-flex items-center gap-2">
+      <button
+        onPointerDown={onPointerDown}
+        onPointerUp={onPointerUp}
+        onPointerCancel={()=>timer.current && clearTimeout(timer.current)}
+        onContextMenu={(e)=>{ e.preventDefault(); setOpen(o=>!o) }}
+        aria-label="React to comment"
+        className="h-7 px-2 rounded bg-white/10 text-xs"
+      >
+        React
+      </button>
+
+      {open && (
+        <div className="absolute z-20 -top-11 left-0">
+          <ReactionBar onSelect={react}/>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2 text-xs text-white/80">
+        {summary.slice(0,4).map(s=>(
+          <span key={s.emoji} className="inline-flex items-center gap-1">
+            <span>{s.emoji}</span><span className="text-[10px]">{s.count}</span>
+          </span>
+        ))}
+        {!!summary.length && <button onClick={clearReaction} className="text-[10px] text-white/50 hover:underline">Clear</button>}
+      </div>
+    </div>
+  )
+}

--- a/src/components/reactions/ReactionBar.tsx
+++ b/src/components/reactions/ReactionBar.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+const EMOJIS = ['👍','🔥','😂','😢','🤗','🤬','🙄']
+
+export default function ReactionBar({ onSelect }: { onSelect: (emoji: string) => void }) {
+  return (
+    <div className="flex gap-1 rounded bg-white/10 p-1 shadow">
+      {EMOJIS.map(e => (
+        <button
+          key={e}
+          onClick={() => onSelect(e)}
+          className="h-8 w-8 flex items-center justify-center rounded hover:bg-white/20"
+          aria-label={e}
+        >
+          {e}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/supabase/migrations/20250903000000_comment_reactions.sql
+++ b/supabase/migrations/20250903000000_comment_reactions.sql
@@ -1,0 +1,54 @@
+-- Comment reactions table and triggers
+
+-- Reuse reaction_emoji from post reactions. Create comment reactions.
+
+create table if not exists comment_reactions (
+  comment_id uuid not null references comments(id) on delete cascade,
+  user_id    uuid not null references auth.users(id) on delete cascade,
+  emoji      reaction_emoji not null,
+  created_at timestamptz default now(),
+  primary key (comment_id, user_id)
+);
+create index if not exists idx_comment_reactions_comment on comment_reactions(comment_id);
+create index if not exists idx_comment_reactions_emoji   on comment_reactions(emoji);
+
+-- Roll up into comments.like_count so existing UI/sorts still work.
+create or replace function refresh_comment_reaction_count(p_comment uuid) returns void
+language sql security definer set search_path=public as $$
+  update comments c
+     set like_count = (select count(*) from comment_reactions r where r.comment_id = c.id)
+   where c.id = p_comment;
+$$;
+
+create or replace function trg_comment_reactions_upd() returns trigger
+language plpgsql security definer as $$
+begin
+  perform refresh_comment_reaction_count(coalesce(new.comment_id, old.comment_id));
+  return coalesce(new, old);
+end $$;
+
+drop trigger if exists t_cr_ai on comment_reactions;
+drop trigger if exists t_cr_au on comment_reactions;
+drop trigger if exists t_cr_ad on comment_reactions;
+create trigger t_cr_ai after insert on comment_reactions for each row execute function trg_comment_reactions_upd();
+create trigger t_cr_au after update on comment_reactions for each row execute function trg_comment_reactions_upd();
+create trigger t_cr_ad after delete on comment_reactions for each row execute function trg_comment_reactions_upd();
+
+-- RLS
+alter table comment_reactions enable row level security;
+do $$ begin
+  create policy if not exists cr_select_all on comment_reactions for select using (true);
+  create policy if not exists cr_upsert_own on comment_reactions for all
+    using (auth.uid() = user_id) with check (auth.uid() = user_id);
+end $$;
+
+-- Summary RPC for quick UI display
+create or replace function comment_reaction_summary(p_comment uuid)
+returns table(emoji reaction_emoji, count int)
+language sql stable as $$
+  select emoji, count(*)::int
+  from comment_reactions
+  where comment_id = p_comment
+  group by emoji
+  order by count desc;
+$$;


### PR DESCRIPTION
## Summary
- add `comment_reactions` table, triggers and summary RPC
- expose API route for reacting to comments
- add client UI with long-press picker and integrate into comments

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68b0d43d37f08327bad0c2c8e0f0400d