### PR TITLE
Add camp rewards gamification system

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import Search from '@/pages/Search'
 import NotificationsPage from '@/pages/Notifications'
 import Messages from '@/pages/Messages'
 import MessageRequests from '@/pages/MessageRequests'
+import Camp from '@/pages/Camp'
 
 function App() {
   return (
@@ -123,6 +124,14 @@ function App() {
                 </RouteGuard>
               } 
             />
+              <Route
+                path="/camp"
+                element={
+                  <RouteGuard>
+                    <Camp />
+                  </RouteGuard>
+                }
+              />
             <Route 
               path="/:username" 
               element={

--- a/src/app/api/game/claim/action/route.ts
+++ b/src/app/api/game/claim/action/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function POST(req: Request){
+  const { action, targetType, targetId } = await req.json().catch(()=>({}));
+  if(!action) return NextResponse.json({ error:'bad_request' },{ status:400 });
+  const sb = createClient(); const { data:u } = await sb.auth.getUser();
+  if(!u?.user) return NextResponse.json({ error:'unauthorized' },{status:401});
+  const { data, error } = await sb.rpc('game_award_action', {
+    p_user: u.user.id, p_action: action, p_target_type: targetType || 'none', p_target: targetId || null
+  });
+  if (error) return NextResponse.json({ error:'failed' },{ status:500 });
+  return NextResponse.json({ awarded: data || [] });
+}

--- a/src/app/api/game/claim/daily/route.ts
+++ b/src/app/api/game/claim/daily/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function POST(){
+  const sb = createClient(); const { data:u } = await sb.auth.getUser();
+  if(!u?.user) return NextResponse.json({ error:'unauthorized' }, { status: 401 });
+  const { data, error } = await sb.rpc('game_claim_daily', { p_user: u.user.id });
+  if (error) return NextResponse.json({ error:'already_or_failed' }, { status: 400 });
+  return NextResponse.json({ awarded: data || [] });
+}

--- a/src/app/api/game/craft/route.ts
+++ b/src/app/api/game/craft/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function POST(req: Request){
+  const { recipe, times = 1 } = await req.json().catch(()=>({}));
+  if(!recipe) return NextResponse.json({ error:'bad_request' },{status:400});
+  const sb = createClient(); const { data:u } = await sb.auth.getUser();
+  if(!u?.user) return NextResponse.json({ error:'unauthorized' },{status:401});
+  const { data, error } = await sb.rpc('game_craft', { p_user: u.user.id, p_recipe_slug: recipe, p_times: times });
+  if (error) return NextResponse.json({ error:'craft_failed' },{status:400});
+  return NextResponse.json({ created: data || [] });
+}

--- a/src/app/api/game/gift/route.ts
+++ b/src/app/api/game/gift/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function POST(req: Request){
+  const { toUserId, itemSlug, qty } = await req.json().catch(()=>({}));
+  if(!toUserId || !itemSlug || !qty) return NextResponse.json({ error:'bad_request' },{status:400});
+  const sb = createClient(); const { data:u } = await sb.auth.getUser();
+  if(!u?.user) return NextResponse.json({ error:'unauthorized' },{status:401});
+  const { data, error } = await sb.rpc('game_gift', { p_from: u.user.id, p_to: toUserId, p_item: itemSlug, p_qty: qty });
+  if (error || data !== true) return NextResponse.json({ error:'gift_failed' },{status:400});
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/game/inventory/route.ts
+++ b/src/app/api/game/inventory/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function GET(){
+  const sb = createClient(); const { data:u } = await sb.auth.getUser();
+  if(!u?.user) return NextResponse.json({ items: [] });
+  const [inv, items] = await Promise.all([
+    sb.from('inventories').select('item_slug, qty').eq('user_id', u.user.id),
+    sb.from('game_items').select('slug, name, emoji, kind')
+  ]);
+  const meta = new Map((items.data||[]).map(i => [i.slug, i]));
+  const rows = (inv.data||[]).filter(r=>r.qty>0).map(r => ({ ...meta.get(r.item_slug), qty: r.qty }));
+  return NextResponse.json({ items: rows });
+}

--- a/src/app/api/game/recipes/route.ts
+++ b/src/app/api/game/recipes/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function GET(){
+  const sb = createClient();
+  const [recipes, ings, items] = await Promise.all([
+    sb.from('game_recipes').select('*'),
+    sb.from('game_recipe_ingredients').select('*'),
+    sb.from('game_items').select('slug,name,emoji')
+  ]);
+  const meta = new Map((items.data||[]).map(i => [i.slug, i]));
+  const map = new Map<string, any>();
+  (recipes.data||[]).forEach(r => map.set(r.slug, { ...r, ingredients: [] as any[] }));
+  (ings.data||[]).forEach(g => {
+    const r = [...map.values()].find(x => x.id === g.recipe_id);
+    if (r) r.ingredients.push({ ...g, item: meta.get(g.item_slug) });
+  });
+  return NextResponse.json({ items: [...map.values()] });
+}

--- a/src/app/api/groups/[id]/posts/route.ts
+++ b/src/app/api/groups/[id]/posts/route.ts
@@ -13,6 +13,10 @@ export async function POST(req: Request, { params }: { params: { id: string } })
     author_id: u.user.id, body: text, media: media||[], status: 'published', group_id: params.id
   }).select('id').single();
   if (error) return NextResponse.json({ error:'create_failed' }, { status:500 });
+  await fetch(new URL('/api/game/claim/action', process.env.NEXT_PUBLIC_APP_ORIGIN), {
+    method:'POST', headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({ action:'post', targetType:'post', targetId: data.id })
+  });
   return NextResponse.json({ postId: data.id });
 }
 

--- a/src/app/api/posts/[id]/like/route.ts
+++ b/src/app/api/posts/[id]/like/route.ts
@@ -38,6 +38,10 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
     .from('post_likes')
     .insert({ post_id: params.id, user_id: user.id })
   if (insertError) return NextResponse.json({ error: insertError.message }, { status: 500 })
+  await fetch(new URL('/api/game/claim/action', process.env.NEXT_PUBLIC_APP_ORIGIN), {
+    method:'POST', headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({ action:'react', targetType:'post', targetId: params.id })
+  });
 
   // notify post author
   try {

--- a/src/components/game/CraftPanel.tsx
+++ b/src/components/game/CraftPanel.tsx
@@ -1,0 +1,26 @@
+'use client';
+import useSWR from 'swr';
+
+export default function CraftPanel(){
+  const { data: inv } = useSWR('/api/game/inventory', (u)=>fetch(u).then(r=>r.json()));
+  const { data: rec } = useSWR('/api/game/recipes', (u)=>fetch(u).then(r=>r.json()));
+  const inventory = new Map((inv?.items||[]).map((i:any)=>[i.slug, i.qty]));
+
+  async function craft(slug:string){
+    const r = await fetch('/api/game/craft',{ method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ recipe: slug, times: 1 }) });
+    const j = await r.json(); alert(j.created?.length ? `Crafted ${j.created[0].output_slug} × ${j.created[0].crafted}` : 'Not enough ingredients');
+  }
+
+  return (
+    <div className="rounded-lg border border-white/10 p-4 space-y-4">
+      <div className="text-sm font-semibold">Campfire Crafting</div>
+      {(rec?.items||[]).map((r:any)=>(
+        <div key={r.slug} className="rounded bg-white/5 p-3">
+          <div className="text-sm font-medium">{r.name}</div>
+          <div className="text-xs text-white/60 mt-1">Needs: {r.ingredients.map((g:any)=>`${g.item?.emoji||''} ${g.item?.name||g.item_slug}×${g.qty}`).join(', ')}</div>
+          <button onClick={()=>craft(r.slug)} className="mt-2 h-8 px-3 rounded bg-white/10 text-sm">Craft</button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/game/GiftModal.tsx
+++ b/src/components/game/GiftModal.tsx
@@ -1,0 +1,52 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function GiftModal({ open, onClose }:{ open:boolean; onClose:()=>void }){
+  const [inv, setInv] = useState<any[]>([]);
+  const [q,setQ]=useState(''); const [people,setPeople]=useState<any[]>([]);
+  const [to,setTo]=useState<string|undefined>(); const [item,setItem]=useState<string|undefined>(); const [qty,setQty]=useState<number>(1);
+
+  useEffect(()=>{ if(open){ fetch('/api/game/inventory').then(r=>r.json()).then(j=>setInv(j.items||[])); } },[open]);
+  async function search(v:string){ setQ(v); const r=await fetch('/api/search/users?q='+encodeURIComponent(v)); setPeople((await r.json()).items||[]); }
+  async function send(){
+    if(!to||!item||!qty) return;
+    const r = await fetch('/api/game/gift',{ method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ toUserId: to, itemSlug: item, qty }) });
+    const j = await r.json();
+    alert(j.ok?'Gift sent!':'Gift failed'); onClose();
+  }
+
+  if(!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 bg-black/50" onClick={onClose}>
+      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-md rounded-lg bg-[#0B1C13] border border-white/10 p-3" onClick={e=>e.stopPropagation()}>
+        <div className="text-sm font-semibold mb-2">Gift Items</div>
+        <input value={q} onChange={e=>search(e.target.value)} placeholder="Search friend…" className="w-full h-9 px-2 rounded bg-white/10"/>
+        <div className="mt-2 max-h-28 overflow-auto">
+          {people.map((p:any)=>(
+            <button key={p.id} onClick={()=>setTo(p.id)} className={"w-full text-left px-2 py-1 rounded " + (to===p.id?'bg-white/10':'hover:bg-white/5')}>
+              {p.display_name || p.username}
+            </button>
+          ))}
+        </div>
+
+        <div className="mt-3">
+          <div className="text-xs text-white/60 mb-1">Choose item</div>
+          <div className="grid grid-cols-2 gap-2 max-h-32 overflow-auto">
+            {inv.map(it=>(
+              <button key={it.slug} onClick={()=>setItem(it.slug)} className={"px-2 py-2 rounded bg-white/5 text-left " + (item===it.slug?'outline outline-1 outline-white/30':'')}>
+                <div className="text-lg">{it.emoji}</div>
+                <div className="text-xs">{it.name} ×{it.qty}</div>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 mt-3">
+          <input type="number" min={1} value={qty} onChange={e=>setQty(parseInt(e.target.value||'1',10))} className="w-24 h-9 px-2 rounded bg-white/10"/>
+          <button onClick={send} className="h-9 px-3 rounded bg-background-sand text-black text-sm">Send</button>
+          <button onClick={onClose} className="h-9 px-3 rounded bg-white/10 text-sm">Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/game/Pantry.tsx
+++ b/src/components/game/Pantry.tsx
@@ -1,0 +1,33 @@
+'use client';
+import useSWR from 'swr';
+
+export default function Pantry(){
+  const { data, mutate } = useSWR('/api/game/inventory', (u)=>fetch(u).then(r=>r.json()));
+  const items = data?.items || [];
+
+  async function claimDaily(){
+    const r = await fetch('/api/game/claim/daily', { method:'POST' });
+    const j = await r.json();
+    if (j.awarded?.length) alert('Daily kit: ' + j.awarded.map((a:any)=>`${a.item_slug}×${a.qty}`).join(', '));
+    mutate();
+  }
+
+  return (
+    <div className="rounded-lg border border-white/10 p-4">
+      <div className="flex items-center justify-between">
+        <div className="text-sm font-semibold">Camp Pantry</div>
+        <button onClick={claimDaily} className="h-8 px-3 rounded bg-background-sand text-black text-sm">Claim Daily Kit</button>
+      </div>
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mt-3">
+        {items.map((it:any)=>(
+          <div key={it.slug} className="rounded bg-white/5 p-3">
+            <div className="text-2xl">{it.emoji}</div>
+            <div className="text-sm mt-1">{it.name}</div>
+            <div className="text-xs text-white/60">x{it.qty}</div>
+          </div>
+        ))}
+        {!items.length && <div className="text-sm text-white/60">No items yet. Earn by posting, reacting, and sharing!</div>}
+      </div>
+    </div>
+  );
+}

--- a/src/components/game/awardToast.ts
+++ b/src/components/game/awardToast.ts
@@ -1,0 +1,4 @@
+export function awardToast(awarded: { item_slug: string; qty: number }[]|undefined) {
+  if (!awarded?.length) return;
+  alert('You earned: ' + awarded.map(a => `${a.item_slug}×${a.qty}`).join(', '));
+}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,4 +1,5 @@
 import { supabase } from "@/integrations/supabase/client"
+import { awardToast } from '@/components/game/awardToast'
 
 export interface Post {
   id: string
@@ -59,6 +60,7 @@ export async function createPost(text: string, media: Post['media'] = []): Promi
     .single()
 
   if (error) throw error
+  await fetch('/api/game/claim/action', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ action:'share', targetType:'post', targetId: postId }) }).then(r=>r.json()).then(j=>awardToast(j.awarded));
 
   return {
     ...post,
@@ -71,6 +73,7 @@ export async function createDraftPost(): Promise<string> {
   const { data, error } = await supabase.rpc('create_draft_post')
   
   if (error) throw error
+  await fetch('/api/game/claim/action', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ action:'share', targetType:'post', targetId: postId }) }).then(r=>r.json()).then(j=>awardToast(j.awarded));
   
   return data
 }
@@ -83,6 +86,7 @@ export async function publishPost(postId: string, text: string, media: Post['med
   })
 
   if (error) throw error
+  await fetch('/api/game/claim/action', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ action:'share', targetType:'post', targetId: postId }) }).then(r=>r.json()).then(j=>awardToast(j.awarded));
 
   // Fetch the complete post with profile data
   const { data: fullPost, error: fetchError } = await supabase
@@ -128,6 +132,7 @@ export async function fetchFeed(cursor?: string): Promise<Post[]> {
   })
 
   if (error) throw error
+  await fetch('/api/game/claim/action', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ action:'share', targetType:'post', targetId: postId }) }).then(r=>r.json()).then(j=>awardToast(j.awarded));
 
   // Get additional data for each post (profiles and likes)
   const postIds = feedPosts?.map(p => p.id) || []
@@ -206,6 +211,7 @@ export async function toggleLike(postId: string): Promise<{ like_count: number; 
       .insert({ post_id: postId, user_id: user.id })
 
     if (insertError) throw insertError
+    await fetch('/api/game/claim/action', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ action:'react', targetType:'post', targetId: postId }) }).then(r=>r.json()).then(j=>awardToast(j.awarded));
 
     // Get updated post
     const { data: post, error: postError } = await supabase
@@ -241,4 +247,5 @@ export async function sharePost(postId: string): Promise<void> {
     .eq('id', postId)
 
   if (error) throw error
+  await fetch('/api/game/claim/action', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ action:'share', targetType:'post', targetId: postId }) }).then(r=>r.json()).then(j=>awardToast(j.awarded));
 }

--- a/src/pages/Camp.tsx
+++ b/src/pages/Camp.tsx
@@ -1,0 +1,11 @@
+import Pantry from '@/components/game/Pantry'
+import CraftPanel from '@/components/game/CraftPanel'
+
+export default function Camp(){
+  return (
+    <div className="p-4 space-y-4">
+      <Pantry />
+      <CraftPanel />
+    </div>
+  )
+}

--- a/supabase/migrations/20250904000000_camp_rewards.sql
+++ b/supabase/migrations/20250904000000_camp_rewards.sql
@@ -1,0 +1,286 @@
+-- Camp Rewards system (gamification)
+
+-- ITEMS (canonical)
+create table if not exists game_items (
+  slug text primary key,
+  name text not null,
+  emoji text not null default '',
+  rarity text not null default 'common',
+  kind text not null default 'ingredient', -- ingredient|crafted|badge
+  created_at timestamptz default now()
+);
+
+-- INVENTORY
+create table if not exists inventories (
+  user_id uuid not null references auth.users(id) on delete cascade,
+  item_slug text not null references game_items(slug),
+  qty int not null default 0 check (qty >= 0),
+  updated_at timestamptz default now(),
+  primary key (user_id, item_slug)
+);
+
+-- EARNING RULES (configurable)
+create table if not exists earn_rules (
+  action text primary key,           -- 'post' | 'react' | 'share'
+  item_slug text not null references game_items(slug),
+  qty int not null check (qty > 0),
+  per_day_limit int not null default 0,   -- 0 = unlimited/day
+  per_target_once boolean not null default true
+);
+
+-- CLAIMS (idempotency + daily limits)
+create table if not exists game_claims (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  action text not null,
+  target_type text,                   -- 'post'|'ember'|'none'
+  target_id uuid,
+  day date not null default (now()::date),
+  created_at timestamptz default now(),
+  unique (user_id, action, target_type, target_id)
+);
+create index if not exists idx_game_claims_user_action_day on game_claims(user_id, action, day);
+
+-- DAILY KIT
+create table if not exists daily_claims (
+  user_id uuid not null references auth.users(id) on delete cascade,
+  day date not null,
+  created_at timestamptz default now(),
+  primary key (user_id, day)
+);
+
+-- GIFTS (ledger)
+create table if not exists game_gifts (
+  id uuid primary key default gen_random_uuid(),
+  from_user uuid not null references auth.users(id) on delete cascade,
+  to_user uuid not null references auth.users(id) on delete cascade,
+  item_slug text not null references game_items(slug),
+  qty int not null check (qty > 0),
+  status text not null default 'sent',
+  created_at timestamptz default now()
+);
+
+-- RECIPES
+create table if not exists game_recipes (
+  id uuid primary key default gen_random_uuid(),
+  slug text unique,
+  name text not null,
+  output_slug text not null references game_items(slug),
+  output_qty int not null default 1
+);
+create table if not exists game_recipe_ingredients (
+  recipe_id uuid references game_recipes(id) on delete cascade,
+  item_slug text references game_items(slug),
+  qty int not null,
+  primary key (recipe_id, item_slug)
+);
+
+-- RLS
+alter table inventories enable row level security;
+alter table earn_rules enable row level security;
+alter table game_items enable row level security;
+alter table game_claims enable row level security;
+alter table daily_claims enable row level security;
+alter table game_gifts enable row level security;
+alter table game_recipes enable row level security;
+alter table game_recipe_ingredients enable row level security;
+
+do $$ begin
+  -- read-only public config
+  create policy if not exists items_read on game_items for select using (true);
+  create policy if not exists rules_read on earn_rules for select using (true);
+  create policy if not exists recipes_read on game_recipes for select using (true);
+  create policy if not exists recipes_ing_read on game_recipe_ingredients for select using (true);
+
+  -- per-user data
+  create policy if not exists inv_self on inventories for select using (auth.uid() = user_id);
+  create policy if not exists inv_self_upd on inventories for update using (auth.uid() = user_id);
+
+  create policy if not exists claims_self on game_claims for select using (auth.uid() = user_id);
+  create policy if not exists daily_self on daily_claims for select using (auth.uid() = user_id);
+
+  create policy if not exists gifts_self on game_gifts for select using (from_user=auth.uid() or to_user=auth.uid());
+end $$;
+
+-- SEED items & rules (safe upserts)
+insert into game_items(slug,name,emoji,rarity,kind) values
+  ('bun','Hot Dog Bun','🥖','common','ingredient'),
+  ('dog','Hot Dog','🌭','common','ingredient'),
+  ('marshmallow','Marshmallow','🟨','common','ingredient'),
+  ('chocolate','Chocolate','🍫','uncommon','ingredient'),
+  ('graham','Graham Cracker','🍪','common','ingredient'),
+  ('stick','Roasting Stick','🪵','common','ingredient'),
+  ('smore','S’more','🍫🔥','rare','crafted'),
+  ('camp_dog','Camp Hot Dog','🌭🔥','rare','crafted')
+on conflict (slug) do nothing;
+
+insert into earn_rules(action,item_slug,qty,per_day_limit,per_target_once) values
+  ('post','chocolate',1,5,true),
+  ('react','marshmallow',1,20,true),
+  ('share','bun',2,10,true)
+on conflict (action) do update set item_slug=excluded.item_slug, qty=excluded.qty, per_day_limit=excluded.per_day_limit, per_target_once=excluded.per_target_once;
+
+-- RECIPES
+do $$ declare rid uuid; begin
+  -- S'more = 2 graham + 1 marshmallow + 1 chocolate
+  insert into game_recipes(slug,name,output_slug,output_qty) values('smore','Craft S’more','smore',1)
+  on conflict (slug) do nothing;
+  select id into rid from game_recipes where slug='smore';
+  insert into game_recipe_ingredients(recipe_id,item_slug,qty) values
+    (rid,'graham',2),(rid,'marshmallow',1),(rid,'chocolate',1)
+  on conflict (recipe_id,item_slug) do nothing;
+
+  -- Camp Hot Dog = 1 bun + 1 dog + 1 stick
+  insert into game_recipes(slug,name,output_slug,output_qty) values('camp_dog','Craft Camp Hot Dog','camp_dog',1)
+  on conflict (slug) do nothing;
+  select id into rid from game_recipes where slug='camp_dog';
+  insert into game_recipe_ingredients(recipe_id,item_slug,qty) values
+    (rid,'bun',1),(rid,'dog',1),(rid,'stick',1)
+  on conflict (recipe_id,item_slug) do nothing;
+end $$;
+
+-- HELPERS (security definer)
+create or replace function _inv_add(p_user uuid, p_item text, p_qty int)
+returns int
+language sql
+security definer
+set search_path = public
+as $$
+  insert into inventories(user_id, item_slug, qty)
+  values (p_user, p_item, greatest(p_qty,0))
+  on conflict (user_id, item_slug)
+  do update set qty = inventories.qty + excluded.qty, updated_at = now()
+  returning qty;
+$$;
+
+-- Award from rules with limits & idempotency
+create or replace function game_award_action(
+  p_user uuid, p_action text, p_target_type text, p_target uuid
+) returns table(item_slug text, qty int)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare r earn_rules%rowtype; today date := now()::date; current int;
+begin
+  select * into r from earn_rules where action = p_action;
+  if not found then return; end if;
+
+  -- per-target idempotency
+  if r.per_target_once and p_target is not null then
+    if exists(select 1 from game_claims where user_id=p_user and action=p_action and target_type=p_target_type and target_id=p_target) then
+      return;
+    end if;
+  end if;
+
+  -- daily limit
+  if r.per_day_limit > 0 then
+    select count(*) into current from game_claims
+      where user_id=p_user and action=p_action and day=today;
+    if current >= r.per_day_limit then
+      return;
+    end if;
+  end if;
+
+  -- record claim
+  insert into game_claims(user_id, action, target_type, target_id, day)
+  values (p_user, p_action, p_target_type, p_target, today)
+  on conflict do nothing;
+
+  -- add inventory
+  perform _inv_add(p_user, r.item_slug, r.qty);
+
+  return query select r.item_slug::text, r.qty::int;
+end $$;
+
+-- Daily camp kit: 3 random picks from a biased pool
+create or replace function game_claim_daily(p_user uuid)
+returns table(item_slug text, qty int)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare today date := now()::date;
+begin
+  if exists(select 1 from daily_claims where user_id=p_user and day=today) then
+    return; -- already claimed
+  end if;
+
+  insert into daily_claims(user_id, day) values(p_user, today);
+
+  -- biased pool (more graham/bun/stick, some chocolate)
+  return query
+  with pool as (
+    select unnest(array['graham','graham','graham','bun','bun','stick','marshmallow','marshmallow','chocolate']) as slug
+  ),
+  picks as (
+    select slug from pool order by random() limit 3
+  )
+  select slug, 1 from picks;
+
+  -- also apply to inventory
+  perform (
+    with pool as (select unnest(array['graham','graham','graham','bun','bun','stick','marshmallow','marshmallow','chocolate']) slug),
+         picks as (select slug from pool order by random() limit 3)
+    select sum(_inv_add(p_user, slug, 1)) from picks
+  );
+end $$;
+
+-- Gift: move items atomically
+create or replace function game_gift(p_from uuid, p_to uuid, p_item text, p_qty int)
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare have int;
+begin
+  if p_qty <= 0 or p_from = p_to then return false; end if;
+
+  select qty into have from inventories where user_id=p_from and item_slug=p_item for update;
+  if have is null or have < p_qty then return false; end if;
+
+  update inventories set qty = qty - p_qty, updated_at=now()
+    where user_id=p_from and item_slug=p_item;
+
+  perform _inv_add(p_to, p_item, p_qty);
+
+  insert into game_gifts(from_user,to_user,item_slug,qty) values(p_from,p_to,p_item,p_qty);
+  return true;
+end $$;
+
+-- Craft: consume ingredients per recipe, produce output
+create or replace function game_craft(p_user uuid, p_recipe_slug text, p_times int default 1)
+returns table(output_slug text, crafted int)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare rid uuid; out_slug text; out_qty int; needed record; i int := 0;
+begin
+  if p_times <= 0 then return; end if;
+  select id, output_slug, output_qty into rid, out_slug, out_qty from game_recipes where slug=p_recipe_slug;
+  if rid is null then return; end if;
+
+  -- compute max craftable by inventory
+  with req as (select item_slug, qty*p_times as need from game_recipe_ingredients where recipe_id=rid),
+       have as (select item_slug, qty from inventories where user_id=p_user),
+       can as (
+         select r.item_slug, coalesce(h.qty,0) as have, r.need
+         from req r left join have h on h.item_slug = r.item_slug
+       )
+  select min(case when have>0 then floor(have::numeric/need::numeric) else 0 end)::int into i
+  from can where need>0;
+  if i is null or i < 1 then return; end if;
+
+  -- consume ingredients
+  for needed in select item_slug, qty*i as take from game_recipe_ingredients where recipe_id=rid loop
+    update inventories set qty = qty - needed.take, updated_at=now()
+      where user_id=p_user and item_slug=needed.item_slug and qty >= needed.take;
+  end loop;
+
+  -- add outputs
+  perform _inv_add(p_user, out_slug, out_qty*i);
+
+  return query select out_slug, out_qty*i;
+end $$;


### PR DESCRIPTION
## Summary
- Add SQL migration defining game item inventory, rules, claims, gifts, and crafting recipes
- Implement game API endpoints for inventory, daily kit, awarding actions, gifting, crafting, and recipes
- Add Camp Pantry, Gift Modal, and Crafting UI with new /camp route and integrate reward claims on posts and reactions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b0dcb13c488327a0fed0ba31309121