### PR TITLE
feat: allow users to add website links to profiles

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -10,6 +10,7 @@ export interface User {
   display_name?: string;
   avatar_url?: string;
   bio?: string;
+  website?: string;
   hobbies: string[];
   interests: string[];
   places_lived: string[];
@@ -64,6 +65,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           username,
           display_name: username,
           bio: null,
+          website: null,
           hobbies: [],
           interests: [],
           places_lived: [],

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -270,6 +270,7 @@ export type Database = {
           search_document: unknown | null
           updated_at: string | null
           username: string | null
+          website: string | null
         }
         Insert: {
           avatar_url?: string | null
@@ -285,6 +286,7 @@ export type Database = {
           search_document?: unknown | null
           updated_at?: string | null
           username?: string | null
+          website?: string | null
         }
         Update: {
           avatar_url?: string | null
@@ -300,6 +302,7 @@ export type Database = {
           search_document?: unknown | null
           updated_at?: string | null
           username?: string | null
+          website?: string | null
         }
         Relationships: []
       }

--- a/src/lib/profiles.ts
+++ b/src/lib/profiles.ts
@@ -7,6 +7,7 @@ export interface User {
   avatar_url?: string
   email: string
   bio?: string
+  website?: string
   hobbies?: string[]
   interests?: string[]
   places_lived?: string[]
@@ -17,6 +18,7 @@ export interface User {
 export interface ProfileUpdateData {
   display_name?: string
   bio?: string
+  website?: string
   hobbies?: string[]
   interests?: string[]
   places_lived?: string[]

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -9,7 +9,7 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
-import { Settings, MapPin, Heart, Briefcase, Calendar } from 'lucide-react'
+import { Settings, MapPin, Heart, Briefcase, Calendar, Globe } from 'lucide-react'
 import { useAuth } from '@/contexts/AuthContext'
 import { getProfileByUsername } from '@/lib/profiles'
 import type { ProfileWithRelation } from '@/lib/profiles'
@@ -87,6 +87,9 @@ export default function Profile() {
   const isOwnProfile = currentUser?.id === profile.id
   const joinedDate = new Date(profile.created_at)
   const timeAgo = formatDistanceToNow(joinedDate, { addSuffix: true })
+  const websiteUrl = profile.website
+    ? (profile.website.startsWith('http') ? profile.website : `https://${profile.website}`)
+    : null
 
   return (
     <div className="min-h-screen bg-background">
@@ -150,13 +153,27 @@ export default function Profile() {
           </div>
 
           <Card className="bg-card border-ink-muted shadow-soft">
-            <CardContent className="p-8">              
+            <CardContent className="p-8">
               {profile.bio && (
                 <p className="text-lg mb-6 leading-relaxed text-card-foreground">
                   {profile.bio}
                 </p>
               )}
-              
+
+              {profile.website && websiteUrl && (
+                <div className="flex items-center gap-2 text-card-foreground/60 mb-4">
+                  <Globe className="h-4 w-4" />
+                  <a
+                    href={websiteUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-accent-warm hover:underline"
+                  >
+                    {profile.website}
+                  </a>
+                </div>
+              )}
+
               <div className="flex items-center gap-2 text-card-foreground/60 mb-8">
                 <Calendar className="h-4 w-4" />
                 <span>Joined {timeAgo}</span>

--- a/src/pages/ProfileSettings.tsx
+++ b/src/pages/ProfileSettings.tsx
@@ -23,6 +23,7 @@ export default function ProfileSettings() {
   const [formData, setFormData] = useState({
     display_name: '',
     bio: '',
+    website: '',
     hobbies: [] as string[],
     interests: [] as string[],
     places_lived: [] as string[],
@@ -34,6 +35,7 @@ export default function ProfileSettings() {
       setFormData({
         display_name: user.display_name || '',
         bio: user.bio || '',
+        website: user.website || '',
         hobbies: user.hobbies || [],
         interests: user.interests || [],
         places_lived: user.places_lived || [],
@@ -66,6 +68,7 @@ export default function ProfileSettings() {
       const updates: ProfileUpdateData = {
         display_name: formData.display_name.trim() || undefined,
         bio: formData.bio.trim() || undefined,
+        website: formData.website.trim() || undefined,
         hobbies: formData.hobbies,
         interests: formData.interests,
         places_lived: formData.places_lived,
@@ -164,6 +167,17 @@ export default function ProfileSettings() {
                   <p className="text-sm text-card-foreground/60 mt-1">
                     This is how your name will appear to others
                   </p>
+                </div>
+
+                <div>
+                  <Label htmlFor="website" className="text-card-foreground">Website</Label>
+                  <Input
+                    id="website"
+                    value={formData.website}
+                    onChange={(e) => handleInputChange('website', e.target.value)}
+                    placeholder="https://example.com"
+                    className="bg-bg-pine border-ink-muted text-text-light placeholder:text-text-light/40"
+                  />
                 </div>
 
                 <div>


### PR DESCRIPTION
## Summary
- expand user profile types to include an optional website
- allow editing website in profile settings
- display website links on profile pages

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find module '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68b0df5a16e8832789945a61749f0add