### PR TITLE
Improve visibility of media picker buttons

### DIFF
--- a/src/components/media/MediaPicker.tsx
+++ b/src/components/media/MediaPicker.tsx
@@ -89,7 +89,7 @@ export function MediaPicker({
       <div className="flex gap-2">
         <Button
           type="button"
-          variant="outline"
+          variant="secondary"
           size="sm"
           onClick={() => imageInputRef.current?.click()}
           disabled={!canAddImages || isUploading}
@@ -106,7 +106,7 @@ export function MediaPicker({
         
         <Button
           type="button"
-          variant="outline"
+          variant="secondary"
           size="sm"
           onClick={() => videoInputRef.current?.click()}
           disabled={!canAddVideo || isUploading}


### PR DESCRIPTION
## Summary
- use secondary button styling for media picker photo and video buttons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm ci` *(fails: 403 Forbidden fetching jszip)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b12e9a43f083279e90c2ed6c938c7b